### PR TITLE
Spellings for LengthUnits

### DIFF
--- a/Core/Kits/LengthUnits.cs
+++ b/Core/Kits/LengthUnits.cs
@@ -5,7 +5,7 @@ namespace Speckle.Core.Kits
 {
   public static class LengthUnits
   {
-    public const string Millimiters = "mm";
+    public const string Millimeters = "mm";
     public const string Centimeters = "cm";
     public const string Meters = "m";
     public const string Kilometers = "km";
@@ -21,7 +21,7 @@ namespace Speckle.Core.Kits
       switch (from)
       {
         // METRIC
-        case LengthUnits.Millimiters:
+        case LengthUnits.Millimeters:
           switch (to)
           {
             case LengthUnits.Centimeters: return 0.1;
@@ -35,7 +35,7 @@ namespace Speckle.Core.Kits
         case LengthUnits.Centimeters:
           switch (to)
           {
-            case LengthUnits.Millimiters: return 10;
+            case LengthUnits.Millimeters: return 10;
             case LengthUnits.Meters: return 0.01;
             case LengthUnits.Kilometers: return 1e-5;
             case LengthUnits.Inches: return 0.393701;
@@ -46,7 +46,7 @@ namespace Speckle.Core.Kits
         case LengthUnits.Meters:
           switch (to)
           {
-            case LengthUnits.Millimiters: return 1000;
+            case LengthUnits.Millimeters: return 1000;
             case LengthUnits.Centimeters: return 100;
             case LengthUnits.Kilometers: return 1000;
             case LengthUnits.Inches: return 39.3701;
@@ -57,7 +57,7 @@ namespace Speckle.Core.Kits
         case LengthUnits.Kilometers:
           switch (to)
           {
-            case LengthUnits.Millimiters: return 1000000;
+            case LengthUnits.Millimeters: return 1000000;
             case LengthUnits.Centimeters: return 100000;
             case LengthUnits.Meters: return 1000;
             case LengthUnits.Inches: return 39370.1;
@@ -70,7 +70,7 @@ namespace Speckle.Core.Kits
         case LengthUnits.Inches:
           switch (to)
           {
-            case LengthUnits.Millimiters: return 25.4;
+            case LengthUnits.Millimeters: return 25.4;
             case LengthUnits.Centimeters: return 2.54;
             case LengthUnits.Meters: return 0.0254;
             case LengthUnits.Kilometers: return 2.54e-5;
@@ -81,7 +81,7 @@ namespace Speckle.Core.Kits
         case LengthUnits.Feet:
           switch (to)
           {
-            case LengthUnits.Millimiters: return 304.8;
+            case LengthUnits.Millimeters: return 304.8;
             case LengthUnits.Centimeters: return 30.48;
             case LengthUnits.Meters: return 0.3048;
             case LengthUnits.Kilometers: return 0.0003048;
@@ -92,7 +92,7 @@ namespace Speckle.Core.Kits
         case LengthUnits.Miles:
           switch (to)
           {
-            case LengthUnits.Millimiters: return 1.609e+6;
+            case LengthUnits.Millimeters: return 1.609e+6;
             case LengthUnits.Centimeters: return 160934;
             case LengthUnits.Meters: return 1609.34;
             case LengthUnits.Kilometers: return 1.60934;
@@ -112,7 +112,7 @@ namespace Speckle.Core.Kits
         case "mil":
         case "millimiters":
         case "milimiters":
-          return LengthUnits.Millimiters;
+          return LengthUnits.Millimeters;
         case "cm":
         case "centimetre":
         case "centimeter":

--- a/Core/Kits/LengthUnits.cs
+++ b/Core/Kits/LengthUnits.cs
@@ -110,8 +110,8 @@ namespace Speckle.Core.Kits
       {
         case "mm":
         case "mil":
-        case "millimiters":
-        case "milimiters":
+        case "millimeters":
+        case "millimetres":
           return LengthUnits.Millimeters;
         case "cm":
         case "centimetre":

--- a/Core/Kits/LengthUnits.cs
+++ b/Core/Kits/LengthUnits.cs
@@ -115,11 +115,15 @@ namespace Speckle.Core.Kits
           return LengthUnits.Millimiters;
         case "cm":
         case "centimetre":
+        case "centimeter":
+        case "centimetres":
         case "centimeters":
           return LengthUnits.Centimeters;
         case "m":
         case "meter":
+        case "metre":
         case "meters":
+        case "metres":
           return LengthUnits.Meters;
       }
       var e = new SpeckleException($"Cannot understand what unit {unit} is.");


### PR DESCRIPTION
This fixes the spelling of `LengthUnits.Millimeters` and adds international + American spellings to the `GetUnitsFromString` for consistency.  