### PR TITLE
fix(converter): add `SetContextDocument` to `ISpeckleConverter`

### DIFF
--- a/Core/Kits/ISpeckleConverter.cs
+++ b/Core/Kits/ISpeckleConverter.cs
@@ -1,4 +1,4 @@
-using Speckle.Core.Models;
+﻿using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -60,5 +60,11 @@ namespace Speckle.Core.Kits
     /// </summary>
     /// <returns></returns>
     public IEnumerable<string> GetServicedApplications();
+
+    /// <summary>
+    /// Sets the application document that the converter is targetting
+    /// </summary>
+    /// <param name="doc">The current application document</param>
+    public void SetContextDocument(object doc);
   }
 }

--- a/Core/Kits/ISpeckleConverter.cs
+++ b/Core/Kits/ISpeckleConverter.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Core.Models;
+using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -28,7 +28,7 @@ namespace Speckle.Core.Kits
     public List<Base> ConvertToSpeckle(List<object> objects);
 
     /// <summary>
-    /// Checks if it can onvert a native object to a Speckle one
+    /// Checks if it can convert a native object to a Speckle one
     /// </summary>
     /// <param name="object">Native object to convert</param>
     /// <returns></returns>
@@ -56,7 +56,7 @@ namespace Speckle.Core.Kits
     public bool CanConvertToNative(Base @object);
 
     /// <summary>
-    /// Returns a list of applicaitons serviced by this converter
+    /// Returns a list of applications serviced by this converter
     /// </summary>
     /// <returns></returns>
     public IEnumerable<string> GetServicedApplications();

--- a/Core/Kits/KitManager.cs
+++ b/Core/Kits/KitManager.cs
@@ -35,7 +35,7 @@ namespace Speckle.Core.Kits
     }
      
     /// <summary>
-    /// Gets a sepcific kit.
+    /// Gets a specific kit.
     /// </summary>
     /// <param name="assemblyFullName"></param>
     /// <returns></returns>
@@ -46,7 +46,7 @@ namespace Speckle.Core.Kits
     }
 
     /// <summary>
-    /// Returns a list of all the kits found on this users's device.
+    /// Returns a list of all the kits found on this user's device.
     /// </summary>
     public static IEnumerable<ISpeckleKit> Kits
     {

--- a/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Serialisation/BaseObjectSerializer.cs
@@ -12,7 +12,7 @@ namespace Speckle.Core.Serialisation
 {
   /// <summary>
   /// Json converter that handles base speckle objects. Enables detachment &
-  /// simultaneous transport (persistance) of objects. 
+  /// simultaneous transport (persistence) of objects. 
   /// </summary>
   public class BaseObjectSerializer : Newtonsoft.Json.JsonConverter
   {
@@ -42,7 +42,7 @@ namespace Speckle.Core.Serialisation
     List<bool> DetachLineage { get; set; }
 
     /// <summary>
-    /// Keeps track of the hash chain throught the object tree.
+    /// Keeps track of the hash chain through the object tree.
     /// </summary>
     List<string> Lineage { get; set; }
 


### PR DESCRIPTION
this will break current converters!  `SetContextDocument` will need to be implemented in:

- [x] ConverterRevit (specklesystems/ConverterRevit#7)
- [x] ConverterRhinoGh (specklesystems/ConverterRhinoGh#4)
- [x] ConverterDynamo (specklesystems/ConverterDynamo#3)