### PR TITLE
feat(models): avatar prop in commit & collaborator

### DIFF
--- a/Core/Api/Models.cs
+++ b/Core/Api/Models.cs
@@ -103,6 +103,7 @@ namespace Speckle.Core.Api
     public string id { get; set; }
     public string name { get; set; }
     public string role { get; set; }
+    public string avatar { get; set; }
 
     public override string ToString()
     {
@@ -131,6 +132,7 @@ namespace Speckle.Core.Api
     public string message { get; set; }
     public string authorName { get; set; }
     public string authorId { get; set; }
+    public string authorAvatar {get; set;}
     public string createdAt { get; set; }
 
     public string referencedObject { get; set; }


### PR DESCRIPTION
For user interfaces, it would make sense to add the `avatar` property to things like `Commit` and `Collaborator` so an additional user query doesn't have to happen to get and display this info.

This is a WIP: it simply adds the props to the models in core so work can continue in the DekstopUI, but the necessary changes in Server have not been made to reflect this.

TODO:
- add these to return types in Server
- add them to `Core.ClientOperations`