### PR TITLE
WIP: Dim/dev transport cancellation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,18 @@
 version: 2.1
 jobs:
+
+  # The unit tests. 
+
   unittest:
     working_directory: /temp
+    
     docker: 
       - image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
+    
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    
     steps:
       - checkout
       - run: 
@@ -16,9 +22,13 @@ jobs:
             git submodule update --remote
       - run: dotnet restore
       - run: dotnet build --configuration Release
-      - run: dotnet test Tests/TestsUnit.csproj
+      - run: dotnet test Tests/TestsUnit.csproj --logger:Console;noprogress=true
+  
+  # The integration tests. Spins up a full blown speckle server. 
+
   integrationtest:
     working_directory: /temp
+    
     docker:
       - image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
       - image: 'circleci/redis:6'
@@ -27,6 +37,7 @@ jobs:
           POSTGRES_DB: speckle2_dev
           POSTGRES_PASSWORD: speckle
           POSTGRES_USER: speckle
+    
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -37,6 +48,7 @@ jobs:
       SESSION_SECRET: 'keyboard cat'
       STRATEGY_LOCAL: true
       CANONICAL_URL: 'http://localhost:3000'
+    
     steps:
       - run:
           name: "Install node"
@@ -71,7 +83,8 @@ jobs:
           command: dotnet build --configuration Release
       - run: 
           working_directory: core
-          command: dotnet test IntegrationTests/TestsIntegration.csproj
+          command: dotnet test IntegrationTests/TestsIntegration.csproj --logger:Console;noprogress=true
+
 workflows: 
   test-all:
     jobs: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,22 @@
 version: 2.1
 
-orbs:
-  win: circleci/windows@2.2.0
-
 jobs:
 
-  # The unit tests. 
+  # # The unit tests. 
 
-  unittest:
-    executor:
-      name: win/default
+  # unittest:
+  #   executor:
+  #     name: win/default
     
-    steps:
-      - checkout
-      - run: 
-          name: "Pull core submodules"
-          command: |
-            git submodule init
-            git submodule update --remote
-      - run: dotnet restore
-      - run: dotnet build --configuration Release
-      - run: dotnet test Tests/TestsUnit.csproj
+  #   steps:
+  #     - checkout
+  #     - run: 
+  #         name: "Pull core submodules"
+  #         command: |
+  #           git submodule init
+  #           git submodule update --remote
+  #     - run: dotnet restore
+  #     - run: dotnet test Tests/TestsUnit.csproj
   
   # The integration tests. Spins up a full blown speckle server. 
 
@@ -82,9 +78,11 @@ jobs:
       - run: 
           working_directory: core
           command: dotnet test IntegrationTests/TestsIntegration.csproj --logger:Console;noprogress=true
+      - run: 
+          working_directory: core
+          command: dotnet test Tests/TestsUnit.csproj --logger:Console;noprogress=true
 
 workflows: 
   test-all:
     jobs: 
       - integrationtest
-      - unittest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,25 +2,25 @@ version: 2.1
 
 jobs:
 
-  # # The unit tests. 
+  # The unit tests. 
 
-  # unittest:
-  #   executor:
-  #     name: win/default
+  unit-tests:
+    docker:
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
     
-  #   steps:
-  #     - checkout
-  #     - run: 
-  #         name: "Pull core submodules"
-  #         command: |
-  #           git submodule init
-  #           git submodule update --remote
-  #     - run: dotnet restore
-  #     - run: dotnet test Tests/TestsUnit.csproj
+    steps:
+      - checkout
+      - run: 
+          name: "Pull core submodules"
+          command: |
+            git submodule init
+            git submodule update --remote
+      - run: dotnet restore
+      - run: dotnet test Tests/TestsUnit.csproj < /dev/null
   
   # The integration tests. Spins up a full blown speckle server. 
 
-  integrationtest:
+  integration-tests:
     working_directory: /temp
     
     docker:
@@ -77,12 +77,10 @@ jobs:
           command: dotnet build --configuration Release
       - run: 
           working_directory: core
-          command: dotnet test IntegrationTests/TestsIntegration.csproj --logger:Console;noprogress=true
-      - run: 
-          working_directory: core
-          command: dotnet test Tests/TestsUnit.csproj --logger:Console;noprogress=true
+          command: dotnet test IntegrationTests/TestsIntegration.csproj --logger:"Console;noprogress=true"
 
 workflows: 
-  test-all:
+  test:
     jobs: 
-      - integrationtest
+      - integration-tests
+      - unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     working_directory: /temp
     
     docker: 
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
+      - image: mcr.microsoft.com/dotnet/core/sdk:2.1
     
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,15 @@
 version: 2.1
+
+orbs:
+  win: circleci/windows@2.2.0
+
 jobs:
 
   # The unit tests. 
 
   unittest:
-    working_directory: /temp
-    
-    docker: 
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.1
-    
-    environment:
-      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    executor:
+      name: win/default
     
     steps:
       - checkout
@@ -22,7 +20,7 @@ jobs:
             git submodule update --remote
       - run: dotnet restore
       - run: dotnet build --configuration Release
-      - run: dotnet test Tests/TestsUnit.csproj --logger:Console;noprogress=true
+      - run: dotnet test Tests/TestsUnit.csproj
   
   # The integration tests. Spins up a full blown speckle server. 
 

--- a/Core/Api/Client.GraphqlClientOperations.cs
+++ b/Core/Api/Client.GraphqlClientOperations.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Core/Api/Client.GraphqlClientOperations.cs
+++ b/Core/Api/Client.GraphqlClientOperations.cs
@@ -10,11 +10,21 @@ namespace Speckle.Core.Api
 {
   public partial class Client
   {
+
     /// <summary>
-    /// Gets the current user
+    /// Gets the current user.
     /// </summary>
     /// <returns></returns>
     public async Task<User> UserGet()
+    {
+      return await UserGet(CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Gets the current user.
+    /// </summary>
+    /// <returns></returns>
+    public async Task<User> UserGet(CancellationToken cancellationToken)
     {
       try
       {
@@ -35,7 +45,7 @@ namespace Speckle.Core.Api
                     }"
         };
 
-        var res = await GQLClient.SendMutationAsync<UserData>(request);
+        var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not get user"), res.Errors);
@@ -49,14 +59,25 @@ namespace Speckle.Core.Api
       }
     }
 
+
     /// <summary>
-    /// Searches for a user on the server
+    /// Searches for a user on the server.
     /// </summary>
     /// <param name="query">String to search for. Must be at least 3 characters</param>
     /// <param name="limit">Max number of users to return</param>
     /// <returns></returns>
-    /// <exception cref="Exception"></exception>
     public async Task<List<User>> UserSearch(string query, int limit = 10)
+    {
+      return await UserSearch(CancellationToken.None, query: query, limit: limit);
+    }
+
+    /// <summary>
+    /// Searches for a user on the server.
+    /// </summary>
+    /// <param name="query">String to search for. Must be at least 3 characters</param>
+    /// <param name="limit">Max number of users to return</param>
+    /// <returns></returns>
+    public async Task<List<User>> UserSearch(CancellationToken cancellationToken, string query, int limit = 10)
     {
       try
       {
@@ -78,17 +99,17 @@ namespace Speckle.Core.Api
           Variables = new
           {
             query,
-            limit 
+            limit
           }
         };
-        var res = await GQLClient.SendMutationAsync<UserSearchData>(request);
+        var res = await GQLClient.SendMutationAsync<UserSearchData>(request, cancellationToken);
 
-        if ( res.Errors != null )
+        if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not search users"), res.Errors);
 
         return res.Data.userSearch.items;
       }
-      catch ( Exception e )
+      catch (Exception e)
       {
         Log.CaptureException(e);
         throw e;
@@ -105,6 +126,18 @@ namespace Speckle.Core.Api
     /// <param name="commitsLimit">Max number of commits per branch to retrieve</param>
     /// <returns></returns>
     public async Task<Stream> StreamGet(string id, int branchesLimit = 10, int commitsLimit = 10)
+    {
+      return await StreamGet(CancellationToken.None, id, branchesLimit, commitsLimit);
+    }
+
+    /// <summary>
+    /// Gets a stream by id, includes commits and branches
+    /// </summary>
+    /// <param name="id">Id of the stream to get</param>
+    /// <param name="branchesLimit">Max number of branches to retrieve</param>
+    /// <param name="commitsLimit">Max number of commits per branch to retrieve</param>
+    /// <returns></returns>
+    public async Task<Stream> StreamGet(CancellationToken cancellationToken, string id, int branchesLimit = 10, int commitsLimit = 10)
     {
       try
       {
@@ -152,7 +185,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<StreamData>(request);
+        var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not get stream"), res.Errors);
@@ -166,13 +199,22 @@ namespace Speckle.Core.Api
       }
     }
 
-
     /// <summary>
     /// Gets all streams for the current user
     /// </summary>
     /// <param name="limit">Max number of streams to return</param>
     /// <returns></returns>
     public async Task<List<Stream>> StreamsGet(int limit = 10)
+    {
+      return await StreamsGet(CancellationToken.None, limit);
+    }
+
+    /// <summary>
+    /// Gets all streams for the current user
+    /// </summary>
+    /// <param name="limit">Max number of streams to return</param>
+    /// <returns></returns>
+    public async Task<List<Stream>> StreamsGet(CancellationToken cancellationToken, int limit = 10)
     {
       try
       {
@@ -210,7 +252,7 @@ namespace Speckle.Core.Api
                     }}"
         };
 
-        var res = await GQLClient.SendMutationAsync<UserData>(request);
+        var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not get streams"), res.Errors);
@@ -231,6 +273,17 @@ namespace Speckle.Core.Api
     /// <param name="limit">Max number of streams to return</param>
     /// <returns></returns>
     public async Task<List<Stream>> StreamSearch(string query, int limit = 10)
+    {
+      return await StreamSearch(CancellationToken.None, query, limit);
+    }
+
+    /// <summary>
+    /// Searches the user's streams by name, description, and ID
+    /// </summary>
+    /// <param name="query">String query to search for</param>
+    /// <param name="limit">Max number of streams to return</param>
+    /// <returns></returns>
+    public async Task<List<Stream>> StreamSearch(CancellationToken cancellationToken, string query, int limit = 10)
     {
       try
       {
@@ -262,14 +315,14 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<StreamsData>(request);
+        var res = await GQLClient.SendMutationAsync<StreamsData>(request, cancellationToken);
 
-        if ( res.Errors != null )
+        if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not search streams"), res.Errors);
 
         return res.Data.streams.items;
       }
-      catch ( Exception e )
+      catch (Exception e)
       {
         Log.CaptureException(e);
         throw e;
@@ -283,6 +336,16 @@ namespace Speckle.Core.Api
     /// <returns>The stream's id.</returns>
     public async Task<string> StreamCreate(StreamCreateInput streamInput)
     {
+      return await StreamCreate(CancellationToken.None, streamInput);
+    }
+
+    /// <summary>
+    /// Creates a stream.
+    /// </summary>
+    /// <param name="streamInput"></param>
+    /// <returns>The stream's id.</returns>
+    public async Task<string> StreamCreate(CancellationToken cancellationToken, StreamCreateInput streamInput)
+    {
       try
       {
         var request = new GraphQLRequest
@@ -294,7 +357,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not create stream"), res.Errors);
@@ -315,6 +378,16 @@ namespace Speckle.Core.Api
     /// <returns>The stream's id.</returns>
     public async Task<bool> StreamUpdate(StreamUpdateInput streamInput)
     {
+      return await StreamUpdate(CancellationToken.None, streamInput);
+    }
+
+    /// <summary>
+    /// Updates a stream.
+    /// </summary>
+    /// <param name="streamInput">Note: the id field needs to be a valid stream id.</param>
+    /// <returns>The stream's id.</returns>
+    public async Task<bool> StreamUpdate(CancellationToken cancellationToken, StreamUpdateInput streamInput)
+    {
       try
       {
         var request = new GraphQLRequest
@@ -326,7 +399,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not update stream"), res.Errors);
@@ -347,6 +420,16 @@ namespace Speckle.Core.Api
     /// <returns></returns>
     public async Task<bool> StreamDelete(string id)
     {
+      return await StreamDelete(CancellationToken.None, id);
+    }
+
+    /// <summary>
+    /// Deletes a stream.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    public async Task<bool> StreamDelete(CancellationToken cancellationToken, string id)
+    {
       try
       {
         var request = new GraphQLRequest
@@ -358,7 +441,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not delete stream"), res.Errors);
@@ -381,6 +464,18 @@ namespace Speckle.Core.Api
     /// <param name="role"></param>
     /// <returns></returns>
     public async Task<bool> StreamGrantPermission(StreamGrantPermissionInput permissionInput)
+    {
+      return await StreamGrantPermission(CancellationToken.None, permissionInput);
+    }
+
+    /// <summary>
+    /// Grants permissions to a user on a given stream.
+    /// </summary>
+    /// <param name="streamId"></param>
+    /// <param name="userId"></param>
+    /// <param name="role"></param>
+    /// <returns></returns>
+    public async Task<bool> StreamGrantPermission(CancellationToken cancellationToken, StreamGrantPermissionInput permissionInput)
     {
       try
       {
@@ -419,6 +514,17 @@ namespace Speckle.Core.Api
     /// <returns></returns>
     public async Task<bool> StreamRevokePermission(StreamRevokePermissionInput permissionInput)
     {
+      return await StreamRevokePermission(CancellationToken.None, permissionInput);
+    }
+
+    /// <summary>
+    /// Revokes permissions of a user on a given stream.
+    /// </summary>
+    /// <param name="streamId"></param>
+    /// <param name="userId"></param>
+    /// <returns></returns>
+    public async Task<bool> StreamRevokePermission(CancellationToken cancellationToken, StreamRevokePermissionInput permissionInput)
+    {
       try
       {
         var request = new GraphQLRequest
@@ -450,12 +556,23 @@ namespace Speckle.Core.Api
     #endregion
 
     #region branches
+
     /// <summary>
     /// Creates a branch on a stream.
     /// </summary>
     /// <param name="branchInput"></param>
     /// <returns>The stream's id.</returns>
     public async Task<string> BranchCreate(BranchCreateInput branchInput)
+    {
+      return await BranchCreate(CancellationToken.None, branchInput);
+    }
+
+    /// <summary>
+    /// Creates a branch on a stream.
+    /// </summary>
+    /// <param name="branchInput"></param>
+    /// <returns>The stream's id.</returns>
+    public async Task<string> BranchCreate(CancellationToken cancellationToken, BranchCreateInput branchInput)
     {
       try
       {
@@ -468,7 +585,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not create branch"), res.Errors);
@@ -489,6 +606,16 @@ namespace Speckle.Core.Api
     /// <returns>The stream's id.</returns>
     public async Task<bool> BranchUpdate(BranchUpdateInput branchInput)
     {
+      return await BranchUpdate(CancellationToken.None, branchInput);
+    }
+
+    /// <summary>
+    /// Updates a branch.
+    /// </summary>
+    /// <param name="branchInput"></param>
+    /// <returns>The stream's id.</returns>
+    public async Task<bool> BranchUpdate(CancellationToken cancellationToken, BranchUpdateInput branchInput)
+    {
       try
       {
         var request = new GraphQLRequest
@@ -500,7 +627,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not update branch"), res.Errors);
@@ -521,6 +648,16 @@ namespace Speckle.Core.Api
     /// <returns></returns>
     public async Task<bool> BranchDelete(BranchDeleteInput branchInput)
     {
+      return await BranchDelete(CancellationToken.None, branchInput);
+    }
+
+    /// <summary>
+    /// Deletes a stream.
+    /// </summary>
+    /// <param name="branchInput"></param>
+    /// <returns></returns>
+    public async Task<bool> BranchDelete(CancellationToken cancellationToken, BranchDeleteInput branchInput)
+    {
       try
       {
         var request = new GraphQLRequest
@@ -532,7 +669,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not delete branch"), res.Errors);
@@ -548,12 +685,23 @@ namespace Speckle.Core.Api
     #endregion
 
     #region commits
+
     /// <summary>
     /// Creates a commit on a branch.
     /// </summary>
     /// <param name="commitInput"></param>
     /// <returns>The commit id.</returns>
     public async Task<string> CommitCreate(CommitCreateInput commitInput)
+    {
+      return await CommitCreate(CancellationToken.None, commitInput);
+    }
+
+    /// <summary>
+    /// Creates a commit on a branch.
+    /// </summary>
+    /// <param name="commitInput"></param>
+    /// <returns>The commit id.</returns>
+    public async Task<string> CommitCreate(CancellationToken cancellationToken, CommitCreateInput commitInput)
     {
       try
       {
@@ -566,7 +714,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not create commit"), res.Errors);
@@ -587,6 +735,16 @@ namespace Speckle.Core.Api
     /// <returns>The stream's id.</returns>
     public async Task<bool> CommitUpdate(CommitUpdateInput commitInput)
     {
+      return await CommitUpdate(CancellationToken.None, commitInput);
+    }
+
+    /// <summary>
+    /// Updates a commit.
+    /// </summary>
+    /// <param name="commitInput"></param>
+    /// <returns>The stream's id.</returns>
+    public async Task<bool> CommitUpdate(CancellationToken cancellationToken, CommitUpdateInput commitInput)
+    {
       try
       {
         var request = new GraphQLRequest
@@ -598,7 +756,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not update commit"), res.Errors);
@@ -619,6 +777,16 @@ namespace Speckle.Core.Api
     /// <returns></returns>
     public async Task<bool> CommitDelete(CommitDeleteInput commitInput)
     {
+      return await CommitDelete(CancellationToken.None, commitInput);
+    }
+
+    /// <summary>
+    /// Deletes a commit.
+    /// </summary>
+    /// <param name="commitInput"></param>
+    /// <returns></returns>
+    public async Task<bool> CommitDelete(CancellationToken cancellationToken, CommitDeleteInput commitInput)
+    {
       try
       {
         var request = new GraphQLRequest
@@ -630,7 +798,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not delete commit"), res.Errors);
@@ -643,6 +811,7 @@ namespace Speckle.Core.Api
         throw e;
       }
     }
+
     #endregion
 
   }

--- a/Core/Api/Client.GraphqlClientOperations.cs
+++ b/Core/Api/Client.GraphqlClientOperations.cs
@@ -713,6 +713,7 @@ namespace Speckle.Core.Api
           Query = $@"query Stream($streamId: String!, $commitId: String!) {{
                       stream(id: $streamId) {{
                         commit(id: $commitId){{
+                          id,
                           message,
                           referencedObject,
                           createdAt,

--- a/Core/Api/Client.GraphqlClientOperations.cs
+++ b/Core/Api/Client.GraphqlClientOperations.cs
@@ -15,9 +15,9 @@ namespace Speckle.Core.Api
     /// Gets the current user.
     /// </summary>
     /// <returns></returns>
-    public async Task<User> UserGet()
+    public Task<User> UserGet()
     {
-      return await UserGet(CancellationToken.None);
+      return UserGet(CancellationToken.None);
     }
 
     /// <summary>
@@ -45,7 +45,7 @@ namespace Speckle.Core.Api
                     }"
         };
 
-        var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not get user"), res.Errors);
@@ -66,9 +66,9 @@ namespace Speckle.Core.Api
     /// <param name="query">String to search for. Must be at least 3 characters</param>
     /// <param name="limit">Max number of users to return</param>
     /// <returns></returns>
-    public async Task<List<User>> UserSearch(string query, int limit = 10)
+    public Task<List<User>> UserSearch(string query, int limit = 10)
     {
-      return await UserSearch(CancellationToken.None, query: query, limit: limit);
+      return UserSearch(CancellationToken.None, query: query, limit: limit);
     }
 
     /// <summary>
@@ -102,7 +102,7 @@ namespace Speckle.Core.Api
             limit
           }
         };
-        var res = await GQLClient.SendMutationAsync<UserSearchData>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<UserSearchData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not search users"), res.Errors);
@@ -125,9 +125,9 @@ namespace Speckle.Core.Api
     /// <param name="branchesLimit">Max number of branches to retrieve</param>
     /// <param name="commitsLimit">Max number of commits per branch to retrieve</param>
     /// <returns></returns>
-    public async Task<Stream> StreamGet(string id, int branchesLimit = 10, int commitsLimit = 10)
+    public Task<Stream> StreamGet(string id, int branchesLimit = 10, int commitsLimit = 10)
     {
-      return await StreamGet(CancellationToken.None, id, branchesLimit, commitsLimit);
+      return StreamGet(CancellationToken.None, id, branchesLimit, commitsLimit);
     }
 
     /// <summary>
@@ -185,7 +185,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not get stream"), res.Errors);
@@ -204,9 +204,9 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="limit">Max number of streams to return</param>
     /// <returns></returns>
-    public async Task<List<Stream>> StreamsGet(int limit = 10)
+    public Task<List<Stream>> StreamsGet(int limit = 10)
     {
-      return await StreamsGet(CancellationToken.None, limit);
+      return StreamsGet(CancellationToken.None, limit);
     }
 
     /// <summary>
@@ -252,7 +252,7 @@ namespace Speckle.Core.Api
                     }}"
         };
 
-        var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not get streams"), res.Errors);
@@ -272,9 +272,9 @@ namespace Speckle.Core.Api
     /// <param name="query">String query to search for</param>
     /// <param name="limit">Max number of streams to return</param>
     /// <returns></returns>
-    public async Task<List<Stream>> StreamSearch(string query, int limit = 10)
+    public Task<List<Stream>> StreamSearch(string query, int limit = 10)
     {
-      return await StreamSearch(CancellationToken.None, query, limit);
+      return StreamSearch(CancellationToken.None, query, limit);
     }
 
     /// <summary>
@@ -315,7 +315,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<StreamsData>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<StreamsData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not search streams"), res.Errors);
@@ -334,9 +334,9 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="streamInput"></param>
     /// <returns>The stream's id.</returns>
-    public async Task<string> StreamCreate(StreamCreateInput streamInput)
+    public Task<string> StreamCreate(StreamCreateInput streamInput)
     {
-      return await StreamCreate(CancellationToken.None, streamInput);
+      return StreamCreate(CancellationToken.None, streamInput);
     }
 
     /// <summary>
@@ -357,7 +357,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not create stream"), res.Errors);
@@ -376,9 +376,9 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="streamInput">Note: the id field needs to be a valid stream id.</param>
     /// <returns>The stream's id.</returns>
-    public async Task<bool> StreamUpdate(StreamUpdateInput streamInput)
+    public Task<bool> StreamUpdate(StreamUpdateInput streamInput)
     {
-      return await StreamUpdate(CancellationToken.None, streamInput);
+      return StreamUpdate(CancellationToken.None, streamInput);
     }
 
     /// <summary>
@@ -399,7 +399,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not update stream"), res.Errors);
@@ -418,9 +418,9 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>
-    public async Task<bool> StreamDelete(string id)
+    public Task<bool> StreamDelete(string id)
     {
-      return await StreamDelete(CancellationToken.None, id);
+      return StreamDelete(CancellationToken.None, id);
     }
 
     /// <summary>
@@ -441,7 +441,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not delete stream"), res.Errors);
@@ -463,9 +463,9 @@ namespace Speckle.Core.Api
     /// <param name="userId"></param>
     /// <param name="role"></param>
     /// <returns></returns>
-    public async Task<bool> StreamGrantPermission(StreamGrantPermissionInput permissionInput)
+    public Task<bool> StreamGrantPermission(StreamGrantPermissionInput permissionInput)
     {
-      return await StreamGrantPermission(CancellationToken.None, permissionInput);
+      return StreamGrantPermission(CancellationToken.None, permissionInput);
     }
 
     /// <summary>
@@ -492,7 +492,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not grant permission"), res.Errors);
@@ -512,9 +512,9 @@ namespace Speckle.Core.Api
     /// <param name="streamId"></param>
     /// <param name="userId"></param>
     /// <returns></returns>
-    public async Task<bool> StreamRevokePermission(StreamRevokePermissionInput permissionInput)
+    public Task<bool> StreamRevokePermission(StreamRevokePermissionInput permissionInput)
     {
-      return await StreamRevokePermission(CancellationToken.None, permissionInput);
+      return StreamRevokePermission(CancellationToken.None, permissionInput);
     }
 
     /// <summary>
@@ -539,7 +539,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not revoke permission"), res.Errors);
@@ -562,9 +562,9 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="branchInput"></param>
     /// <returns>The stream's id.</returns>
-    public async Task<string> BranchCreate(BranchCreateInput branchInput)
+    public Task<string> BranchCreate(BranchCreateInput branchInput)
     {
-      return await BranchCreate(CancellationToken.None, branchInput);
+      return BranchCreate(CancellationToken.None, branchInput);
     }
 
     /// <summary>
@@ -585,7 +585,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not create branch"), res.Errors);
@@ -604,9 +604,9 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="branchInput"></param>
     /// <returns>The stream's id.</returns>
-    public async Task<bool> BranchUpdate(BranchUpdateInput branchInput)
+    public Task<bool> BranchUpdate(BranchUpdateInput branchInput)
     {
-      return await BranchUpdate(CancellationToken.None, branchInput);
+      return BranchUpdate(CancellationToken.None, branchInput);
     }
 
     /// <summary>
@@ -627,7 +627,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not update branch"), res.Errors);
@@ -646,9 +646,9 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="branchInput"></param>
     /// <returns></returns>
-    public async Task<bool> BranchDelete(BranchDeleteInput branchInput)
+    public Task<bool> BranchDelete(BranchDeleteInput branchInput)
     {
-      return await BranchDelete(CancellationToken.None, branchInput);
+      return BranchDelete(CancellationToken.None, branchInput);
     }
 
     /// <summary>
@@ -669,7 +669,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not delete branch"), res.Errors);
@@ -691,9 +691,9 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="commitInput"></param>
     /// <returns>The commit id.</returns>
-    public async Task<string> CommitCreate(CommitCreateInput commitInput)
+    public Task<string> CommitCreate(CommitCreateInput commitInput)
     {
-      return await CommitCreate(CancellationToken.None, commitInput);
+      return CommitCreate(CancellationToken.None, commitInput);
     }
 
     /// <summary>
@@ -714,7 +714,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not create commit"), res.Errors);
@@ -733,9 +733,9 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="commitInput"></param>
     /// <returns>The stream's id.</returns>
-    public async Task<bool> CommitUpdate(CommitUpdateInput commitInput)
+    public Task<bool> CommitUpdate(CommitUpdateInput commitInput)
     {
-      return await CommitUpdate(CancellationToken.None, commitInput);
+      return CommitUpdate(CancellationToken.None, commitInput);
     }
 
     /// <summary>
@@ -756,7 +756,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not update commit"), res.Errors);
@@ -775,9 +775,9 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="commitInput"></param>
     /// <returns></returns>
-    public async Task<bool> CommitDelete(CommitDeleteInput commitInput)
+    public Task<bool> CommitDelete(CommitDeleteInput commitInput)
     {
-      return await CommitDelete(CancellationToken.None, commitInput);
+      return CommitDelete(CancellationToken.None, commitInput);
     }
 
     /// <summary>
@@ -798,7 +798,7 @@ namespace Speckle.Core.Api
           }
         };
 
-        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken);
+        var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
           Log.CaptureAndThrow(new GraphQLException("Could not delete commit"), res.Errors);

--- a/Core/Api/Models.cs
+++ b/Core/Api/Models.cs
@@ -92,6 +92,11 @@ namespace Speckle.Core.Api
     public List<Collaborator> collaborators { get; set; }
     public Branches branches { get; set; }
 
+    /// <summary>
+    /// Set only in the case that you've requested this through <see cref="Client.CommitGet(System.Threading.CancellationToken, string, string)"/>.
+    /// </summary>
+    public Commit commit { get; set; }
+
     public override string ToString()
     {
       return $"Stream ({name} | {id})";
@@ -208,7 +213,6 @@ namespace Speckle.Core.Api
   public class StreamData
   {
     public Stream stream { get; set; }
-
   }
 
   public class StreamsData

--- a/Core/Api/Operations/Operations.Receive.cs
+++ b/Core/Api/Operations/Operations.Receive.cs
@@ -20,7 +20,9 @@ namespace Speckle.Core.Api
     /// <param name="objectId"></param>
     /// <param name="remoteTransport">The transport to receive from.</param>
     /// <param name="localTransport">Leave null to use the default cache.</param>
-    /// <param name="onProgressAction"></param>
+    /// <param name="onProgressAction">Action invoked on progress iterations.</param>
+    /// <param name="onErrorAction">Action invoked on internal errors.</param>
+    /// <param name="onTotalChildrenCountKnown">Action invoked once the total count of objects is known.</param>
     /// <returns></returns>
     public static Task<Base> Receive(string objectId, ITransport remoteTransport = null, ITransport localTransport = null, Action<ConcurrentDictionary<string, int>> onProgressAction = null, Action<string, Exception> onErrorAction = null, Action<int> onTotalChildrenCountKnown = null)
     {
@@ -42,7 +44,9 @@ namespace Speckle.Core.Api
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to send notice of cancellation.</param>
     /// <param name="remoteTransport">The transport to receive from.</param>
     /// <param name="localTransport">Leave null to use the default cache.</param>
-    /// <param name="onProgressAction"></param>
+    /// <param name="onProgressAction">Action invoked on progress iterations.</param>
+    /// <param name="onErrorAction">Action invoked on internal errors.</param>
+    /// <param name="onTotalChildrenCountKnown">Action invoked once the total count of objects is known.</param>
     /// <returns></returns>
     public static async Task<Base> Receive(string objectId, CancellationToken cancellationToken, ITransport remoteTransport = null, ITransport localTransport = null, Action<ConcurrentDictionary<string, int>> onProgressAction = null, Action<string, Exception> onErrorAction = null, Action<int> onTotalChildrenCountKnown = null)
     {

--- a/Core/Api/Operations/Operations.Receive.cs
+++ b/Core/Api/Operations/Operations.Receive.cs
@@ -6,6 +6,7 @@ using Speckle.Core.Transports;
 using System.Collections.Concurrent;
 using Speckle.Core.Logging;
 using Sentry.Protocol;
+using System.Threading;
 
 namespace Speckle.Core.Api
 {
@@ -20,7 +21,28 @@ namespace Speckle.Core.Api
     /// <param name="localTransport">Leave null to use the default cache.</param>
     /// <param name="onProgressAction"></param>
     /// <returns></returns>
-    public static async Task<Base> Receive(string objectId, ITransport remoteTransport = null, ITransport localTransport = null, Action<ConcurrentDictionary<string, int>> onProgressAction = null)
+    public static Task<Base> Receive(string objectId, ITransport remoteTransport = null, ITransport localTransport = null, Action<ConcurrentDictionary<string, int>> onProgressAction = null, Action<string, Exception> onErrorAction = null)
+    {
+      return Receive(
+        objectId,
+        CancellationToken.None,
+        remoteTransport,
+        localTransport,
+        onProgressAction,
+        onErrorAction
+        );
+    }
+
+    /// <summary>
+    /// Receives an object from a transport.
+    /// </summary>
+    /// <param name="objectId"></param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to send notice of cancellation.</param>
+    /// <param name="remoteTransport">The transport to receive from.</param>
+    /// <param name="localTransport">Leave null to use the default cache.</param>
+    /// <param name="onProgressAction"></param>
+    /// <returns></returns>
+    public static async Task<Base> Receive(string objectId, CancellationToken cancellationToken, ITransport remoteTransport = null, ITransport localTransport = null, Action<ConcurrentDictionary<string, int>> onProgressAction = null, Action<string, Exception> onErrorAction = null)
     {
       Log.AddBreadcrumb("Receive");
 
@@ -30,26 +52,48 @@ namespace Speckle.Core.Api
       var internalProgressAction = GetInternalProgressAction(localProgressDict, onProgressAction);
 
       localTransport = localTransport != null ? localTransport : new SQLiteTransport();
+      localTransport.OnErrorAction = onErrorAction;
+      localTransport.OnProgressAction = internalProgressAction;
+      localTransport.CancellationToken = cancellationToken;
 
       serializer.ReadTransport = localTransport;
       serializer.OnProgressAction = internalProgressAction;
+      serializer.OnErrorAction = onErrorAction;
+      serializer.CancellationToken = cancellationToken;
 
+      // First we try and get the object from the local transport. If it's there, we assume all its children are there, and proceed with deserialisation. 
+      // This assumption is hard-wired into the SDK. Read below. 
       var objString = localTransport.GetObject(objectId);
 
       if (objString != null)
       {
         return JsonConvert.DeserializeObject<Base>(objString, settings);
-      } else if( remoteTransport == null )
+      }
+      else if (remoteTransport == null)
       {
         Log.CaptureAndThrow(new SpeckleException($"Could not find specified object using the local transport, and you didn't provide a fallback remote from which to pull it."), SentryLevel.Error);
       }
 
+      // If we've reached this stage, it means that we didn't get a local transport hit on our object, so we will proceed to get it from the provided remote transport. 
+      // This is done by copying itself and all its children from the remote transport into the local one.
+      remoteTransport.OnErrorAction = onErrorAction;
+      remoteTransport.OnProgressAction = internalProgressAction;
+      remoteTransport.CancellationToken = cancellationToken;
+
       Log.AddBreadcrumb("RemoteHit");
       objString = await remoteTransport.CopyObjectAndChildren(objectId, localTransport);
-
+      
+      // Wait for the local transport to finish "writing" - in this case, it signifies that the remote transport has done pushing copying objects into it. (TODO: I can see some scenarios where latency can screw things up, and we should rather wait on the remote transport).
       await localTransport.WriteComplete();
 
+      // Proceed to deserialise the object, now safely knowing that all its children are present in the local (fast) transport. 
       return JsonConvert.DeserializeObject<Base>(objString, settings);
+
+      // Summary: 
+      // Basically, receiving an object (and all its subchildren) operates with two transports, one that is potentially slow, and one that is fast. 
+      // The fast transport ("localTransport") is used syncronously inside the deserialisation routine to get the value of nested references and set them. The slow transport ("remoteTransport") is used to get the raw data and populate the local transport with all necessary data for a successful deserialisation of the object. 
+      // Note: if properly implemented, there is no hard distinction between what is a local or remote transport; it's still just a transport. So, for example, if you want to receive an object without actually writing it first to a local transport, you can just pass a Server/S3 transport as a local transport. 
+      // This is not reccommended, but shows what you can do. Another tidbit: the local transport does not need to be disk-bound; it can easily be an in memory transport. In memory transports are the fastest ones, but they're of limited use for more 
     }
 
   }

--- a/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Api/Operations/Operations.Send.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -24,8 +25,28 @@ namespace Speckle.Core.Api
     /// <param name="transports">Where you want to send them.</param>
     /// <param name="useDefaultCache">Toggle for the default cache. If set to false, it will only send to the provided transports.</param>
     /// <param name="onProgressAction">Action that gets triggered on every progress tick (keeps track of all transports).</param>
-    /// <returns></returns>
+    /// <returns>The id (hash) of the object.</returns>
     public static async Task<string> Send(Base @object, List<ITransport> transports = null, bool useDefaultCache = true, Action<ConcurrentDictionary<string, int>> onProgressAction = null)
+    {
+      return await Send(
+        @object: @object,
+        cancellationToken: CancellationToken.None,
+        transports: transports,
+        useDefaultCache: useDefaultCache,
+        onProgressAction: onProgressAction
+        );
+    }
+
+    /// <summary>
+    /// Sends an object via the provided transports. Defaults to the local cache. 
+    /// </summary>
+    /// <param name="object">The object you want to send.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to send notice of cancellation.</param>
+    /// <param name="transports">Where you want to send them.</param>
+    /// <param name="useDefaultCache">Toggle for the default cache. If set to false, it will only send to the provided transports.</param>
+    /// <param name="onProgressAction">Action that gets triggered on every progress tick (keeps track of all transports).</param>
+    /// <returns>The id (hash) of the object.</returns>
+    public static async Task<string> Send(Base @object, CancellationToken cancellationToken, List<ITransport> transports = null, bool useDefaultCache = true, Action<ConcurrentDictionary<string, int>> onProgressAction = null)
     {
       Log.AddBreadcrumb("Send");
 
@@ -50,10 +71,12 @@ namespace Speckle.Core.Api
       var internalProgressAction = Operations.GetInternalProgressAction(localProgressDict, onProgressAction);
 
       serializer.OnProgressAction = internalProgressAction;
+      serializer.CancellationToken = cancellationToken;
 
-      foreach(var t in transports)
+      foreach (var t in transports)
       {
         t.OnProgressAction = internalProgressAction;
+        t.CancellationToken = cancellationToken;
         serializer.WriteTransports.Add(t);
       }
 
@@ -73,9 +96,6 @@ namespace Speckle.Core.Api
     /// <para>Note: If you're aiming to create a revision/commit afterwards, wrap your object list in a separate base object and use the other method.</para>
     /// </summary>
     /// <param name="objects">Base objects to send</param>
-    /// <param name="streamIds">List of StreamIds to send the objects to</param>
-    /// <param name="clients">List of Clients to use</param>
-    /// <param name="localTransport"></param>
     /// <param name="onProgressAction">An action that is invoked with a dictionary argument containing key value pairs of (process name, processed items).</param>
     /// <returns>The object's id (hash).</returns>
     public static async Task<List<string>> Send(IEnumerable<Base> objects, List<ITransport> transports = null, bool useDefaultCache = true, Action<ConcurrentDictionary<string, int>> onProgressAction = null)

--- a/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Api/Operations/Operations.Send.cs
@@ -65,7 +65,7 @@ namespace Speckle.Core.Api
 
       if (useDefaultCache)
       {
-        transports.Insert(0, new SQLiteTransport() { TransportName = "Local Cache" });
+        transports.Insert(0, new SQLiteTransport() { TransportName = "LC" });
       }
 
       var (serializer, settings) = GetSerializerInstance();
@@ -88,9 +88,10 @@ namespace Speckle.Core.Api
       }
 
       var obj = JsonConvert.SerializeObject(@object, settings);
-      var hash = JObject.Parse(obj).GetValue("id").ToString();
 
       var transportAwaits = serializer.WriteTransports.Select(t => t.WriteComplete()).ToList();
+
+      if (cancellationToken.IsCancellationRequested) return null;
 
       await Task.WhenAll(transportAwaits).ConfigureAwait(false);
 
@@ -99,6 +100,9 @@ namespace Speckle.Core.Api
         t.EndWrite();
       }
 
+      if (cancellationToken.IsCancellationRequested) return null;
+
+      var hash = JObject.Parse(obj).GetValue("id").ToString();
       return hash;
     }
 

--- a/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Api/Operations/Operations.Send.cs
@@ -82,6 +82,8 @@ namespace Speckle.Core.Api
         t.OnProgressAction = internalProgressAction;
         t.CancellationToken = cancellationToken;
         t.OnErrorAction = onErrorAction;
+        t.BeginWrite();
+
         serializer.WriteTransports.Add(t);
       }
 
@@ -91,6 +93,11 @@ namespace Speckle.Core.Api
       var transportAwaits = serializer.WriteTransports.Select(t => t.WriteComplete()).ToList();
 
       await Task.WhenAll(transportAwaits);
+
+      foreach (var t in transports)
+      {
+        t.EndWrite();
+      }
 
       return hash;
     }

--- a/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Api/Operations/Operations.Send.cs
@@ -92,7 +92,7 @@ namespace Speckle.Core.Api
 
       var transportAwaits = serializer.WriteTransports.Select(t => t.WriteComplete()).ToList();
 
-      await Task.WhenAll(transportAwaits);
+      await Task.WhenAll(transportAwaits).ConfigureAwait(false);
 
       foreach (var t in transports)
       {

--- a/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Api/Operations/Operations.Send.cs
@@ -27,15 +27,15 @@ namespace Speckle.Core.Api
     /// <param name="onProgressAction">Action that gets triggered on every progress tick (keeps track of all transports).</param>
     /// <param name="onErrorAction">Use this to capture and handle any errors from within the transports.</param>
     /// <returns>The id (hash) of the object.</returns>
-    public static async Task<string> Send(Base @object, List<ITransport> transports = null, bool useDefaultCache = true, Action<ConcurrentDictionary<string, int>> onProgressAction = null, Action<string, Exception> onErrorAction = null)
+    public static Task<string> Send(Base @object, List<ITransport> transports = null, bool useDefaultCache = true, Action<ConcurrentDictionary<string, int>> onProgressAction = null, Action<string, Exception> onErrorAction = null)
     {
-      return await Send(
-        @object: @object,
-        cancellationToken: CancellationToken.None,
-        transports: transports,
-        useDefaultCache: useDefaultCache,
-        onProgressAction: onProgressAction,
-        onErrorAction: onErrorAction
+      return Send(
+        @object,
+        CancellationToken.None,
+        transports,
+        useDefaultCache,
+        onProgressAction,
+        onErrorAction
         );
     }
 

--- a/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Api/Operations/Operations.Send.cs
@@ -65,7 +65,7 @@ namespace Speckle.Core.Api
 
       if (useDefaultCache)
       {
-        transports.Insert(0, new SQLiteTransport());
+        transports.Insert(0, new SQLiteTransport() { TransportName = "Local Cache" });
       }
 
       var (serializer, settings) = GetSerializerInstance();

--- a/Core/Api/Operations/Operations.Serialize.cs
+++ b/Core/Api/Operations/Operations.Serialize.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using Newtonsoft.Json;
 using Speckle.Core.Models;
 
@@ -8,22 +9,38 @@ namespace Speckle.Core.Api
   // TODO: cleanup a bit
   public static partial class Operations
   {
+
     /// <summary>
-    /// Serializes a given object. Note: if you want to save and persist an object to speckle, please use any of the "Send" methods.
+    /// Serializes a given object. Note: if you want to save and persist an object to a Speckle Transport or Server, please use any of the "Send" methods. See <see cref="Send(Base, List{Transports.ITransport}, bool, Action{System.Collections.Concurrent.ConcurrentDictionary{string, int}}, Action{string, Exception})"/>.
     /// </summary>
     /// <param name="object"></param>
-    /// <returns></returns>
+    /// <returns>A json string representation of the object.</returns>
     public static string Serialize(Base @object)
     {
-      var (_, settings) = GetSerializerInstance();
+      return Serialize(@object, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Serializes a given object. Note: if you want to save and persist an object to Speckle Transport or Server, please use any of the "Send" methods. See <see cref="Send(Base, List{Transports.ITransport}, bool, Action{System.Collections.Concurrent.ConcurrentDictionary{string, int}}, Action{string, Exception})"/>.
+    /// </summary>
+    /// <param name="object"></param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <returns>A json string representation of the object.</returns>
+    public static string Serialize(Base @object, CancellationToken cancellationToken)
+    {
+      var (serializer, settings) = GetSerializerInstance();
+      serializer.CancellationToken = cancellationToken;
+
       return JsonConvert.SerializeObject(@object, settings);
     }
+
 
     /// <summary>
     /// Serializes a list of objects. Note: if you want to save and persist objects to speckle, please use any of the "Send" methods.
     /// </summary>
     /// <param name="objects"></param>
     /// <returns></returns>
+    [Obsolete("Please use the Serialize(Base @object) function. This function will be removed in later versions.")]
     public static string Serialize(List<Base> objects)
     {
       var (_, settings) = GetSerializerInstance();
@@ -35,20 +52,33 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="objects"></param>
     /// <returns></returns>
-    public static string Serialize(Dictionary<string,Base> objects)
+    [Obsolete("Please use the Serialize(Base @object) function. This function will be removed in later versions.")]
+    public static string Serialize(Dictionary<string, Base> objects)
     {
       var (_, settings) = GetSerializerInstance();
       return JsonConvert.SerializeObject(objects, settings);
     }
 
     /// <summary>
-    /// Deserializes a given object. Note: if you want to pull an object from speckle (either local or remote), please use any of the "Receive" methods.
+    /// Deserializes a given object. Note: if you want to pull an object from a Speckle Transport or Server, please use any of the <see cref="Receive(string, Transports.ITransport, Transports.ITransport, Action{System.Collections.Concurrent.ConcurrentDictionary{string, int}})"/>.
     /// </summary>
-    /// <param name="object"></param>
+    /// <param name="object">The json string representation of a speckle object that you want to deserialise.</param>
     /// <returns></returns>
     public static Base Deserialize(string @object)
     {
-      var (_, settings) = GetSerializerInstance();
+      return Deserialize(@object, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Deserializes a given object. Note: if you want to pull an object from a Speckle Transport or Server, please use any of the <see cref="Receive(string, Transports.ITransport, Transports.ITransport, Action{System.Collections.Concurrent.ConcurrentDictionary{string, int}})"/>.
+    /// </summary>
+    /// <param name="object">The json string representation of a speckle object that you want to deserialise.</param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <returns></returns>
+    public static Base Deserialize(string @object, CancellationToken cancellationToken)
+    {
+      var (serializer, settings) = GetSerializerInstance();
+      serializer.CancellationToken = cancellationToken;
       return JsonConvert.DeserializeObject<Base>(@object, settings);
     }
 
@@ -57,6 +87,7 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="objectArr"></param>
     /// <returns></returns>
+    [Obsolete("Please use the Deserialize(Base @object) function. This function will be removed in later versions.")]
     public static List<Base> DeserializeArray(string objectArr)
     {
       var (_, settings) = GetSerializerInstance();
@@ -68,7 +99,8 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="dictionary"></param>
     /// <returns></returns>
-    public static Dictionary<string,object> DeserializeDictionary(string dictionary)
+    [Obsolete("Please use the Deserialize(Base @object) function. This function will be removed in later versions.")]
+    public static Dictionary<string, object> DeserializeDictionary(string dictionary)
     {
       var (_, settings) = GetSerializerInstance();
       return JsonConvert.DeserializeObject<Dictionary<string, object>>(dictionary, settings);

--- a/Core/Api/Operations/Operations.cs
+++ b/Core/Api/Operations/Operations.cs
@@ -50,5 +50,4 @@ namespace Speckle.Core.Api
       });
     }
   }
-
 }

--- a/Core/Api/Operations/Operations.cs
+++ b/Core/Api/Operations/Operations.cs
@@ -15,8 +15,8 @@ namespace Speckle.Core.Api
   public static partial class Operations
   {
     /// <summary>
-    /// Instantiates an instance of the default object serializer and settings pre-populated with it. 
-    /// <returns>A tuple of Serializer and Settings.</returns>
+    /// Convenience method to instantiate an instance of the default object serializer and settings pre-populated with it.
+    /// </summary>    
     public static (BaseObjectSerializer, JsonSerializerSettings) GetSerializerInstance()
     {
       var serializer = new BaseObjectSerializer();
@@ -33,7 +33,7 @@ namespace Speckle.Core.Api
     }
 
     /// <summary>
-    /// Factory for progress actions to be used internally inside send & receive methods.
+    /// Factory for progress actions used internally inside send & receive methods.
     /// </summary>
     /// <param name="localProgressDict"></param>
     /// <param name="onProgressAction"></param>

--- a/Core/Credentials/AccountManager.cs
+++ b/Core/Credentials/AccountManager.cs
@@ -104,7 +104,7 @@ namespace Speckle.Core.Credentials
       if (defaultAccount == null)
       {
         var firstAccount = GetAccounts().FirstOrDefault();
-        if(firstAccount == null)
+        if (firstAccount == null)
         {
           Log.CaptureAndThrow(new SpeckleException("No Speckle accounts found. Visit the Speckle web app to create one."), level: Sentry.Protocol.SentryLevel.Info);
         }
@@ -121,7 +121,9 @@ namespace Speckle.Core.Credentials
     {
       var _accs = AccountStorage.GetAllObjects();
       foreach (var _acc in _accs)
+      {
         yield return JsonConvert.DeserializeObject<Account>(_acc);
+      }
     }
 
   }

--- a/Core/Credentials/StreamWrapper.cs
+++ b/Core/Credentials/StreamWrapper.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Linq;
+
+namespace Speckle.Core.Credentials
+{
+  public class StreamWrapper
+  {
+    public string AccountId { get; set; }
+    public string ServerUrl { get; set; }
+    public string StreamId { get; set; }
+    public string CommitId { get; set; }
+    public string BranchId { get; set; } // To be used later! 
+
+    public StreamWrapper() { }
+
+    public StreamWrapper(string myString)
+    {
+      Account account = null;
+      Uri uri = null;
+      if (myString.Contains("?u="))
+      {
+        uri = new Uri(myString.Split(new string[] { "?u=" }, StringSplitOptions.None)[0]);
+        ServerUrl = uri.GetLeftPart(UriPartial.Authority);
+
+        AccountId = myString.Split(new string[] { "?u=" }, StringSplitOptions.None)[1];
+        account = AccountManager.GetAccounts().FirstOrDefault(a => a.id == AccountId);
+
+        if (account == null)
+        {
+          account = AccountManager.GetAccounts(ServerUrl).FirstOrDefault();
+          AccountId = account.id;
+        }
+      }
+      else
+      {
+        uri = new Uri(myString);
+        ServerUrl = uri.GetLeftPart(UriPartial.Authority);
+        account = AccountManager.GetAccounts(ServerUrl).FirstOrDefault();
+      }
+
+      if (account == null)
+      {
+        throw new Exception($"You do not have an account for {ServerUrl}. Please create one or add it to the Speckle Manager.");
+      }
+
+      if (uri.Segments.Length < 3)
+      {
+        throw new Exception($"Cannot parse {uri} into a stream wrapper class.");
+      }
+
+      switch (uri.Segments.Length)
+      {
+        case 3: // ie http://speckle.server/streams/8fecc9aa6d
+          if (uri.Segments[1].ToLowerInvariant() == "streams/")
+          {
+            StreamId = uri.Segments[2].Replace("/", "");
+          }
+          else
+          {
+            throw new Exception($"Cannot parse {uri} into a stream wrapper class.");
+          }
+          break;
+        case 5: // ie http://speckle.server/streams/8fecc9aa6d/commits/76a23d7179
+          if (uri.Segments[3].ToLowerInvariant() == "commits/")
+          {
+            StreamId = uri.Segments[2].Replace("/", "");
+            CommitId = uri.Segments[4].Replace("/", "");
+          }
+          else if (uri.Segments[3].ToLowerInvariant() == "branches/")
+          {
+            StreamId = uri.Segments[2].Replace("/", "");
+            BranchId = uri.Segments[4].Replace("/", "");
+          }
+          else
+          {
+            throw new Exception($"Cannot parse {uri} into a stream wrapper class.");
+          }
+          break;
+      }
+    }
+
+    public StreamWrapper(string streamId, string accountId, string serverUrl)
+    {
+      AccountId = accountId;
+      ServerUrl = serverUrl;
+      StreamId = streamId;
+    }
+
+    public override string ToString()
+    {
+      return $"{ServerUrl}/streams/{StreamId}{(CommitId != null ? "/commits/" + CommitId : "")}{(AccountId != null ? "?u=" + AccountId : "")}";
+    }
+
+    public Account GetAccount()
+    {
+      Account account = null;
+
+      account = AccountManager.GetAccounts().FirstOrDefault(a => a.id == AccountId);
+      if (account == null)
+      {
+        account = AccountManager.GetAccounts(ServerUrl).FirstOrDefault();
+      }
+
+      if (account != null)
+      {
+        AccountId = account.id;
+      }
+
+      return account;
+    }
+  }
+}

--- a/Core/Logging/Setup.cs
+++ b/Core/Logging/Setup.cs
@@ -9,6 +9,7 @@ namespace Speckle.Core.Logging
   public static class Setup
   {
     private readonly static string _suuidPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Speckle", "suuid");
+    
     public static void Init(string hostApplication)
     {
       HostApplication = hostApplication;

--- a/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Serialisation/BaseObjectSerializer.cs
@@ -204,7 +204,7 @@ namespace Speckle.Core.Serialisation
       if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
 
       TotalProcessedCount++;
-      OnProgressAction?.Invoke("Deserialization", 1);
+      OnProgressAction?.Invoke("DS", 1);
       return obj;
     }
 
@@ -334,8 +334,6 @@ namespace Speckle.Core.Serialisation
           DetachLineage.RemoveAt(DetachLineage.Count - 1);
         }
 
-        if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
-
         // Check if we actually have any transports present that would warrant a 
         if ((WriteTransports != null && WriteTransports.Count != 0) && RefMinDepthTracker.ContainsKey(Lineage[Lineage.Count - 1]))
         {
@@ -349,17 +347,16 @@ namespace Speckle.Core.Serialisation
         }
         jo.WriteTo(writer);
 
-        if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
-
         if ((DetachLineage.Count == 0 || DetachLineage[DetachLineage.Count - 1]) && WriteTransports != null && WriteTransports.Count != 0)
         {
           var objString = jo.ToString();
           var objId = jo["id"].Value<string>();
 
-          OnProgressAction?.Invoke("Serialization", 1);
+          OnProgressAction?.Invoke("S", 1);
 
           foreach (var transport in WriteTransports)
           {
+            if (CancellationToken.IsCancellationRequested) continue; // Check for cancellation
             transport.SaveObject(objId, objString);
           }
         }
@@ -402,6 +399,7 @@ namespace Speckle.Core.Serialisation
           if (WriteTransports != null && WriteTransports.Count != 0 && arrValue is Base && DetachLineage[DetachLineage.Count - 1])
           {
             var what = JToken.FromObject(arrValue, serializer); // Trigger next
+
             if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
             var refHash = ((JObject)what).GetValue("id").ToString();
 

--- a/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Serialisation/BaseObjectSerializer.cs
@@ -315,9 +315,10 @@ namespace Speckle.Core.Serialisation
           // Set and store a reference, if it is marked as detachable and the transport is not null.
           if (WriteTransports != null && WriteTransports.Count != 0 && propValue is Base && DetachLineage[DetachLineage.Count - 1])
           {
+            var what = JToken.FromObject(propValue, serializer); // Trigger next.
+
             if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
 
-            var what = JToken.FromObject(propValue, serializer); // Trigger next.
             var refHash = ((JObject)what).GetValue("id").ToString();
 
             var reference = new ObjectReference() { referencedId = refHash };
@@ -401,6 +402,7 @@ namespace Speckle.Core.Serialisation
           if (WriteTransports != null && WriteTransports.Count != 0 && arrValue is Base && DetachLineage[DetachLineage.Count - 1])
           {
             var what = JToken.FromObject(arrValue, serializer); // Trigger next
+            if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
             var refHash = ((JObject)what).GetValue("id").ToString();
 
             var reference = new ObjectReference() { referencedId = refHash };

--- a/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Serialisation/BaseObjectSerializer.cs
@@ -61,6 +61,9 @@ namespace Speckle.Core.Serialisation
 
     public Action<string, int> OnProgressAction { get; set; }
 
+    public Action<string, Exception> OnErrorAction { get; set; }
+
+
     public BaseObjectSerializer()
     {
       ResetAndInitialize();

--- a/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Serialisation/BaseObjectSerializer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -22,16 +23,16 @@ namespace Speckle.Core.Serialisation
     /// </summary>
     public string TypeDiscriminator = "speckle_type";
 
-    /// <summary>
-    /// Session transport keeps track, in this serialisation pass only, of what we've serialised.
-    /// </summary>
-    //public ITransport SessionTransport { get; set; }
+    public CancellationToken CancellationToken { get; set; }
 
     /// <summary>
     /// The sync transport. This transport will be used synchronously. 
     /// </summary>
     public ITransport ReadTransport { get; set; }
-
+    
+    /// <summary>
+    /// List of transports to write to.
+    /// </summary>
     public List<ITransport> WriteTransports { get; set; } = new List<ITransport>();
 
     #region Write Json Helper Properties
@@ -84,6 +85,9 @@ namespace Speckle.Core.Serialisation
 
     public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
     {
+      
+      if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+
       if (reader.TokenType == JsonToken.Null)
         return null;
 
@@ -97,11 +101,15 @@ namespace Speckle.Core.Serialisation
 
         foreach (var val in jarr)
         {
-          var whatever = SerializationUtilities.HandleValue(val, serializer);
+          if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+
+          var whatever = SerializationUtilities.HandleValue(val, serializer, CancellationToken);
           list.Add(whatever as Base);
         }
         return list;
       }
+
+      if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
 
       var jObject = JObject.Load(reader);
 
@@ -117,10 +125,14 @@ namespace Speckle.Core.Serialisation
 
         foreach (var val in jObject)
         {
-          dict[val.Key] = SerializationUtilities.HandleValue(val.Value, serializer);
+          if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+
+          dict[val.Key] = SerializationUtilities.HandleValue(val.Value, serializer, CancellationToken);
         }
         return dict;
       }
+
+      if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
 
       var discriminator = Extensions.Value<string>(objType);
 
@@ -142,7 +154,6 @@ namespace Speckle.Core.Serialisation
         }
         else
           Log.CaptureAndThrow(new SpeckleException("Cannot resolve reference. The provided transport could not find it."), level: Sentry.Protocol.SentryLevel.Warning);
-
       }
 
       var type = SerializationUtilities.GetType(discriminator);
@@ -155,8 +166,11 @@ namespace Speckle.Core.Serialisation
       jObject.Remove(TypeDiscriminator);
       jObject.Remove("__closure");
 
+      if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+
       foreach (var jProperty in jObject.Properties())
       {
+        if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
         if (used.Contains(jProperty.Name)) continue;
 
         used.Add(jProperty.Name);
@@ -173,16 +187,19 @@ namespace Speckle.Core.Serialisation
           }
           else
           {
-            var val = SerializationUtilities.HandleValue(jProperty.Value, serializer, property);
+            var val = SerializationUtilities.HandleValue(jProperty.Value, serializer, CancellationToken, property);
             property.ValueProvider.SetValue(obj, val);
           }
         }
         else
         {
           // dynamic properties
-          CallSiteCache.SetValue(jProperty.Name, obj, SerializationUtilities.HandleValue(jProperty.Value, serializer));
+          CallSiteCache.SetValue(jProperty.Name, obj, SerializationUtilities.HandleValue(jProperty.Value, serializer, CancellationToken));
         }
       }
+
+      if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+
       TotalProcessedCount++;
       OnProgressAction?.Invoke("Deserialization", 1);
       return obj;
@@ -216,6 +233,9 @@ namespace Speckle.Core.Serialisation
     // the parent object being last. 
     public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
     {
+      
+      if(CancellationToken.IsCancellationRequested) return; // Check for cancellation
+
       /////////////////////////////////////
       // Path one: nulls
       /////////////////////////////////////
@@ -239,6 +259,8 @@ namespace Speckle.Core.Serialisation
 
       if (value is Base && !(value is ObjectReference))
       {
+        if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+
         var obj = value as Base;
 
         FirstEntry = false;
@@ -255,6 +277,7 @@ namespace Speckle.Core.Serialisation
         // Iterate through the object's properties, one by one, checking for ignored ones
         foreach (var prop in propertyNames)
         {
+          if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
           // Ignore properties starting with a double underscore.
           if (prop.StartsWith("__")) continue;
 
@@ -289,6 +312,8 @@ namespace Speckle.Core.Serialisation
           // Set and store a reference, if it is marked as detachable and the transport is not null.
           if (WriteTransports != null && WriteTransports.Count != 0 && propValue is Base && DetachLineage[DetachLineage.Count - 1])
           {
+            if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+
             var what = JToken.FromObject(propValue, serializer); // Trigger next.
             var refHash = ((JObject)what).GetValue("id").ToString();
 
@@ -305,6 +330,8 @@ namespace Speckle.Core.Serialisation
           DetachLineage.RemoveAt(DetachLineage.Count - 1);
         }
 
+        if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+
         // Check if we actually have any transports present that would warrant a 
         if ((WriteTransports != null && WriteTransports.Count != 0) && RefMinDepthTracker.ContainsKey(Lineage[Lineage.Count - 1]))
         {
@@ -317,6 +344,8 @@ namespace Speckle.Core.Serialisation
           jo.Add("id", JToken.FromObject(hash));
         }
         jo.WriteTo(writer);
+
+        if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
 
         if ((DetachLineage.Count == 0 || DetachLineage[DetachLineage.Count - 1]) && WriteTransports != null && WriteTransports.Count != 0)
         {
@@ -340,6 +369,8 @@ namespace Speckle.Core.Serialisation
       // Path four: lists/arrays & dicts
       /////////////////////////////////////
 
+      if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+
       var type = value.GetType();
 
       // TODO: List handling and dictionary serialisation handling can be sped up significantly if we first check by their inner type.
@@ -349,6 +380,7 @@ namespace Speckle.Core.Serialisation
 
       if (typeof(IEnumerable).IsAssignableFrom(type) && !typeof(IDictionary).IsAssignableFrom(type) && type != typeof(string))
       {
+
         if (TotalProcessedCount == 0 && FirstEntry)
         {
           FirstEntry = false;
@@ -360,6 +392,8 @@ namespace Speckle.Core.Serialisation
         JArray arr = new JArray();
         foreach (var arrValue in ((IEnumerable)value))
         {
+          if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+
           if (arrValue == null) continue;
           if (WriteTransports != null && WriteTransports.Count != 0 && arrValue is Base && DetachLineage[DetachLineage.Count - 1])
           {
@@ -373,6 +407,9 @@ namespace Speckle.Core.Serialisation
           else
             arr.Add(JToken.FromObject(arrValue, serializer)); // Default route
         }
+
+        if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+
         arr.WriteTo(writer);
 
         if (DetachLineage.Count == 1 && FirstEntryWasListOrDict) // are we in a list entry point case?
@@ -380,6 +417,8 @@ namespace Speckle.Core.Serialisation
 
         return;
       }
+
+      if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
 
       if (typeof(IDictionary).IsAssignableFrom(type))
       {
@@ -394,6 +433,7 @@ namespace Speckle.Core.Serialisation
         var dictJo = new JObject();
         foreach (DictionaryEntry kvp in dict)
         {
+          if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
           if (kvp.Value == null) continue;
 
           JToken jToken;
@@ -414,6 +454,8 @@ namespace Speckle.Core.Serialisation
         }
         dictJo.WriteTo(writer);
 
+        if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+
         if (DetachLineage.Count == 1 && FirstEntryWasListOrDict) // are we in a dictionary entry point case?
           DetachLineage.RemoveAt(0);
 
@@ -423,6 +465,8 @@ namespace Speckle.Core.Serialisation
       /////////////////////////////////////
       // Path five: everything else (enums?)
       /////////////////////////////////////
+
+      if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
 
       FirstEntry = false;
       var lastCall = JToken.FromObject(value); // bypasses this converter as we do not pass in the serializer

--- a/Core/Transports/ITransport.cs
+++ b/Core/Transports/ITransport.cs
@@ -25,7 +25,7 @@ namespace Speckle.Core.Transports
     /// <summary>
     /// Used to report errors during the transport's longer operations.
     /// </summary>
-    public Action<string, int> OnErrorAction { get; set; }
+    public Action<string, Exception> OnErrorAction { get; set; }
 
     /// <summary>
     /// Saves an object.

--- a/Core/Transports/ITransport.cs
+++ b/Core/Transports/ITransport.cs
@@ -67,8 +67,10 @@ namespace Speckle.Core.Transports
     /// <summary>
     /// Copies the parent object and all its children to the provided transport.
     /// </summary>
-    /// <param name="hash"></param>
+    /// <param name="id">The id of the object you want to copy.</param>
+    /// <param name="targetTransport">The transport you want to copy the object to.</param>
+    /// <param name="onTotalChildrenCountKnown">(Optional) an action that will be invoked once, when the amount of object children to be copied over is known.</param>
     /// <returns>The string representation of the root object.</returns>
-    public Task<string> CopyObjectAndChildren(string id, ITransport targetTransport);
+    public Task<string> CopyObjectAndChildren(string id, ITransport targetTransport, Action<int> onTotalChildrenCountKnown = null);
   }
 }

--- a/Core/Transports/ITransport.cs
+++ b/Core/Transports/ITransport.cs
@@ -28,6 +28,16 @@ namespace Speckle.Core.Transports
     public Action<string, Exception> OnErrorAction { get; set; }
 
     /// <summary>
+    /// Optional: signals to the transport that writes are about to begin.
+    /// </summary>
+    public void BeginWrite();
+
+    /// <summary>
+    /// Optional: signals to the transport that no more items will need to be written.
+    /// </summary>
+    public void EndWrite();
+
+    /// <summary>
     /// Saves an object.
     /// </summary>
     /// <param name="id">The hash of the object.</param>

--- a/Core/Transports/ITransport.cs
+++ b/Core/Transports/ITransport.cs
@@ -17,7 +17,15 @@ namespace Speckle.Core.Transports
     /// </summary>
     public CancellationToken CancellationToken { get; set; }
 
+    /// <summary>
+    /// Used to report progress during the transport's longer operations.
+    /// </summary>
     public Action<string, int> OnProgressAction { get; set; }
+
+    /// <summary>
+    /// Used to report errors during the transport's longer operations.
+    /// </summary>
+    public Action<string, int> OnErrorAction { get; set; }
 
     /// <summary>
     /// Saves an object.

--- a/Core/Transports/ITransport.cs
+++ b/Core/Transports/ITransport.cs
@@ -1,17 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Speckle.Core.Transports
 {
   /// <summary>
   /// Interface defining the contract for transport implementations.
-  /// TODO: This is not its final form yet. We need to clean it up and "regularise" it a bit. Add some best practices too. Defs in the implementations.
   /// </summary>
   public interface ITransport
   {
     public string TransportName { get; set; }
 
+    /// <summary>
+    /// Should be checked often and gracefully stop all in progress sending if requested.
+    /// </summary>
+    public CancellationToken CancellationToken { get; set; }
 
     public Action<string, int> OnProgressAction { get; set; }
 

--- a/Core/Transports/Memory.cs
+++ b/Core/Transports/Memory.cs
@@ -46,7 +46,7 @@ namespace Speckle.Core.Transports
       Objects[hash] = serializedObject;
       
       SavedObjectCount++;
-      OnProgressAction?.Invoke(TransportName, SavedObjectCount);
+      OnProgressAction?.Invoke(TransportName, 1);
     }
 
     public void SaveObject(string id, ITransport sourceTransport)

--- a/Core/Transports/Memory.cs
+++ b/Core/Transports/Memory.cs
@@ -23,6 +23,8 @@ namespace Speckle.Core.Transports
 
     public Action<string, Exception> OnErrorAction { get; set; }
 
+    public int SavedObjectCount { get; set; } = 0;
+
     public MemoryTransport()
     {
       Log.AddBreadcrumb("New Memory Transport");
@@ -30,11 +32,21 @@ namespace Speckle.Core.Transports
       Objects = new Dictionary<string, string>();
     }
 
+    public void BeginWrite()
+    {
+      SavedObjectCount = 0;
+    }
+
+    public void EndWrite() { }
+
     public void SaveObject(string hash, string serializedObject)
     {
       if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
 
       Objects[hash] = serializedObject;
+      
+      SavedObjectCount++;
+      OnProgressAction?.Invoke(TransportName, SavedObjectCount);
     }
 
     public void SaveObject(string id, ITransport sourceTransport)

--- a/Core/Transports/Memory.cs
+++ b/Core/Transports/Memory.cs
@@ -30,6 +30,8 @@ namespace Speckle.Core.Transports
 
     public void SaveObject(string hash, string serializedObject)
     {
+      if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+
       Objects[hash] = serializedObject;
     }
 
@@ -40,6 +42,8 @@ namespace Speckle.Core.Transports
 
     public string GetObject(string hash)
     {
+      if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+
       if (Objects.ContainsKey(hash)) return Objects[hash];
       else
       {

--- a/Core/Transports/Memory.cs
+++ b/Core/Transports/Memory.cs
@@ -21,7 +21,7 @@ namespace Speckle.Core.Transports
 
     public Action<string, int> OnProgressAction { get; set; }
 
-    public Action<string, int> OnErrorAction { get; set; }
+    public Action<string, Exception> OnErrorAction { get; set; }
 
     public MemoryTransport()
     {

--- a/Core/Transports/Memory.cs
+++ b/Core/Transports/Memory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
@@ -13,6 +14,8 @@ namespace Speckle.Core.Transports
   public class MemoryTransport : ITransport
   {
     public Dictionary<string, string> Objects;
+
+    public CancellationToken CancellationToken { get; set; }
 
     public string TransportName { get; set; } = "Memory";
 

--- a/Core/Transports/Memory.cs
+++ b/Core/Transports/Memory.cs
@@ -21,6 +21,8 @@ namespace Speckle.Core.Transports
 
     public Action<string, int> OnProgressAction { get; set; }
 
+    public Action<string, int> OnErrorAction { get; set; }
+
     public MemoryTransport()
     {
       Log.AddBreadcrumb("New Memory Transport");

--- a/Core/Transports/Memory.cs
+++ b/Core/Transports/Memory.cs
@@ -66,7 +66,7 @@ namespace Speckle.Core.Transports
       }
     }
 
-    public Task<string> CopyObjectAndChildren(string id, ITransport targetTransport)
+    public Task<string> CopyObjectAndChildren(string id, ITransport targetTransport, Action<int> onTotalChildrenCountKnown = null)
     {
       throw new NotImplementedException();
     }

--- a/Core/Transports/SQLite.cs
+++ b/Core/Transports/SQLite.cs
@@ -79,6 +79,7 @@ namespace Speckle.Core.Transports
       //foreach (var str in HexChars)
       //  foreach (var str2 in HexChars)
       //    cart.Add(str + str2);
+      if (CancellationToken.IsCancellationRequested) return;
 
       using (var c = new SQLiteConnection(ConnectionString))
       {
@@ -110,15 +111,13 @@ namespace Speckle.Core.Transports
         cmd = new SQLiteCommand("PRAGMA temp_store=MEMORY;", c);
         cmd.ExecuteNonQuery();
       }
+
+      if (CancellationToken.IsCancellationRequested) return;
     }
 
     public void BeginWrite()
     {
-      if (!GetWriteCompletionStatus())
-      {
-        throw new Exception("Transport is still writing.");
-      }
-
+      Queue = new ConcurrentQueue<(string, string, int)>();
       SavedObjectCount = 0;
     }
 

--- a/Core/Transports/SQLite.cs
+++ b/Core/Transports/SQLite.cs
@@ -114,7 +114,7 @@ namespace Speckle.Core.Transports
 
     public void BeginWrite()
     {
-      if (GetWriteCompletionStatus())
+      if (!GetWriteCompletionStatus())
       {
         throw new Exception("Transport is still writing.");
       }

--- a/Core/Transports/SQLite.cs
+++ b/Core/Transports/SQLite.cs
@@ -292,7 +292,7 @@ namespace Speckle.Core.Transports
       return null; // pass on the duty of null checks to consumers
     }
 
-    public async Task<string> CopyObjectAndChildren(string hash, ITransport targetTransport)
+    public async Task<string> CopyObjectAndChildren(string hash, ITransport targetTransport, Action<int> onTotalChildrenCountKnown = null)
     {
       throw new NotImplementedException();
     }

--- a/Core/Transports/SQLite.cs
+++ b/Core/Transports/SQLite.cs
@@ -15,6 +15,8 @@ namespace Speckle.Core.Transports
   {
     public string TransportName { get; set; } = "LocalTransport";
 
+    public CancellationToken CancellationToken { get; set; }
+
     public string RootPath { get; set; }
 
     public string ConnectionString { get; set; }

--- a/Core/Transports/SQLite.cs
+++ b/Core/Transports/SQLite.cs
@@ -27,6 +27,8 @@ namespace Speckle.Core.Transports
 
     public Action<string, int> OnProgressAction { get; set; }
 
+    public Action<string, int> OnErrorAction { get; set; }
+
     /// <summary>
     /// Timer that ensures queue is consumed if less than MAX_TRANSACTION_SIZE objects are being sent.
     /// </summary>

--- a/DiskTransport/DiskTransport.cs
+++ b/DiskTransport/DiskTransport.cs
@@ -20,7 +20,7 @@ namespace DiskTransport
 
     public Action<string, int> OnProgressAction { get; set; }
 
-    public Action<string, int> OnErrorAction { get; set; }
+    public Action<string, Exception> OnErrorAction { get; set; }
 
     public string RootPath { get; set; }
 

--- a/DiskTransport/DiskTransport.cs
+++ b/DiskTransport/DiskTransport.cs
@@ -26,7 +26,7 @@ namespace DiskTransport
 
     public int SavedObjectCount { get; private set; } = 0;
 
-    public DiskTransport(string basePath)
+    public DiskTransport(string basePath = null)
     {
       if (basePath == null)
         basePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Speckle", "DiskTransportFiles");
@@ -70,7 +70,7 @@ namespace DiskTransport
 
     public void SaveObject(string id, ITransport sourceTransport)
     {
-      if (CancellationToken.IsCancellationRequested) return ; // Check for cancellation
+      if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
 
       var serializedObject = sourceTransport.GetObject(id);
       SaveObject(id, serializedObject);

--- a/DiskTransport/DiskTransport.cs
+++ b/DiskTransport/DiskTransport.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Speckle.Core.Transports;
@@ -14,6 +15,8 @@ namespace DiskTransport
   public class DiskTransport : ITransport
   {
     public string TransportName { get; set; } = "Disk";
+
+    public CancellationToken CancellationToken { get; set; }
 
     public Action<string, int> OnProgressAction { get; set; }
 

--- a/DiskTransport/DiskTransport.cs
+++ b/DiskTransport/DiskTransport.cs
@@ -10,7 +10,7 @@ using Speckle.Core.Transports;
 namespace DiskTransport
 {
   /// <summary>
-  /// Warning! Untested.
+  /// Writes speckle objects to disk.
   /// </summary>
   public class DiskTransport : ITransport
   {
@@ -34,6 +34,8 @@ namespace DiskTransport
 
     public string GetObject(string id)
     {
+      if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+
       var filePath = Path.Combine(RootPath, id);
       if (File.Exists(filePath))
       {
@@ -45,6 +47,8 @@ namespace DiskTransport
 
     public void SaveObject(string id, string serializedObject)
     {
+      if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+
       var filePath = Path.Combine(RootPath, id);
       if (File.Exists(filePath)) return;
 
@@ -53,6 +57,8 @@ namespace DiskTransport
 
     public void SaveObject(string id, ITransport sourceTransport)
     {
+      if (CancellationToken.IsCancellationRequested) return ; // Check for cancellation
+
       var serializedObject = sourceTransport.GetObject(id);
       SaveObject(id, serializedObject);
     }
@@ -64,6 +70,8 @@ namespace DiskTransport
 
     public async Task<string> CopyObjectAndChildren(string id, ITransport targetTransport)
     {
+      if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+
       var parent = GetObject(id);
 
       targetTransport.SaveObject(id, parent);
@@ -75,6 +83,8 @@ namespace DiskTransport
       int i = 0;
       foreach (var kvp in partial.__closure)
       {
+        if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+
         var child = GetObject(kvp.Key);
         targetTransport.SaveObject(kvp.Key, child);
         OnProgressAction?.Invoke($"{TransportName}", i++);

--- a/DiskTransport/DiskTransport.cs
+++ b/DiskTransport/DiskTransport.cs
@@ -64,7 +64,8 @@ namespace DiskTransport
       if (File.Exists(filePath)) return;
 
       File.WriteAllText(filePath, serializedObject, Encoding.UTF8);
-      OnProgressAction?.Invoke(TransportName, SavedObjectCount++);
+      SavedObjectCount++;
+      OnProgressAction?.Invoke(TransportName, SavedObjectCount);
     }
 
     public void SaveObject(string id, ITransport sourceTransport)

--- a/DiskTransport/DiskTransport.cs
+++ b/DiskTransport/DiskTransport.cs
@@ -24,7 +24,7 @@ namespace DiskTransport
 
     public string RootPath { get; set; }
 
-    public int SavedObjectCount { get; set; } = 0;
+    public int SavedObjectCount { get; private set; } = 0;
 
     public DiskTransport(string basePath)
     {
@@ -35,6 +35,13 @@ namespace DiskTransport
 
       Directory.CreateDirectory(RootPath);
     }
+
+    public void BeginWrite()
+    {
+      SavedObjectCount = 0;
+    }
+
+    public void EndWrite() { }
 
     public string GetObject(string id)
     {

--- a/DiskTransport/DiskTransport.cs
+++ b/DiskTransport/DiskTransport.cs
@@ -24,6 +24,8 @@ namespace DiskTransport
 
     public string RootPath { get; set; }
 
+    public int SavedObjectCount { get; set; } = 0;
+
     public DiskTransport(string basePath)
     {
       if (basePath == null)
@@ -55,6 +57,7 @@ namespace DiskTransport
       if (File.Exists(filePath)) return;
 
       File.WriteAllText(filePath, serializedObject, Encoding.UTF8);
+      OnProgressAction?.Invoke(TransportName, SavedObjectCount++);
     }
 
     public void SaveObject(string id, ITransport sourceTransport)

--- a/DiskTransport/DiskTransport.cs
+++ b/DiskTransport/DiskTransport.cs
@@ -81,7 +81,7 @@ namespace DiskTransport
       return;
     }
 
-    public async Task<string> CopyObjectAndChildren(string id, ITransport targetTransport)
+    public async Task<string> CopyObjectAndChildren(string id, ITransport targetTransport, Action<int> onTotalChildrenCountKnown = null)
     {
       if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
 

--- a/DiskTransport/DiskTransport.cs
+++ b/DiskTransport/DiskTransport.cs
@@ -20,6 +20,8 @@ namespace DiskTransport
 
     public Action<string, int> OnProgressAction { get; set; }
 
+    public Action<string, int> OnErrorAction { get; set; }
+
     public string RootPath { get; set; }
 
     public DiskTransport(string basePath)

--- a/MongoDBTransport/MongoDB.cs
+++ b/MongoDBTransport/MongoDB.cs
@@ -36,6 +36,8 @@ namespace Speckle.Core.Transports
 
     public Action<string, int> OnProgressAction { get; set; }
 
+    public Action<string, int> OnErrorAction { get; set; }
+
     /// <summary>
     /// Timer that ensures queue is consumed if less than MAX_TRANSACTION_SIZE objects are being sent.
     /// </summary>

--- a/MongoDBTransport/MongoDB.cs
+++ b/MongoDBTransport/MongoDB.cs
@@ -11,6 +11,7 @@ using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
 
 using Speckle.Core.Logging;
+using System.Threading;
 
 namespace Speckle.Core.Transports
 {
@@ -22,6 +23,8 @@ namespace Speckle.Core.Transports
   public class MongoDBTransport : IDisposable, ITransport
   {
     public string TransportName { get; set; } = "MongoTransport";
+
+    public CancellationToken CancellationToken { get; set; }
 
     public string ConnectionString { get; set; }
 
@@ -55,7 +58,7 @@ namespace Speckle.Core.Transports
 
       Initialize();
 
-      WriteTimer = new Timer() { AutoReset = true, Enabled = false, Interval = PollInterval };
+      WriteTimer = new System.Timers.Timer() { AutoReset = true, Enabled = false, Interval = PollInterval };
       WriteTimer.Elapsed += WriteTimerElapsed;
     }
 

--- a/MongoDBTransport/MongoDB.cs
+++ b/MongoDBTransport/MongoDB.cs
@@ -36,7 +36,7 @@ namespace Speckle.Core.Transports
 
     public Action<string, int> OnProgressAction { get; set; }
 
-    public Action<string, int> OnErrorAction { get; set; }
+    public Action<string, Exception> OnErrorAction { get; set; }
 
     /// <summary>
     /// Timer that ensures queue is consumed if less than MAX_TRANSACTION_SIZE objects are being sent.

--- a/MongoDBTransport/MongoDB.cs
+++ b/MongoDBTransport/MongoDB.cs
@@ -189,7 +189,7 @@ namespace Speckle.Core.Transports
       return null;
     }
 
-    public async Task<string> CopyObjectAndChildren(string hash, ITransport targetTransport)
+    public async Task<string> CopyObjectAndChildren(string hash, ITransport targetTransport, Action<int> onTotalChildrenCountKnown = null)
     {
       throw new NotImplementedException();
     }

--- a/ServerTransport/Server.cs
+++ b/ServerTransport/Server.cs
@@ -332,7 +332,7 @@ namespace Speckle.Core.Transports
               if (partial.__closure != null)
                 onTotalChildrenCountKnown?.Invoke(partial.__closure.Count);
             }
-            OnProgressAction?.Invoke($"GET Remote ({Client.BaseAddress.ToString()})", i++); // possibly make this more friendly
+            OnProgressAction?.Invoke($"GET Remote ({Client.BaseAddress})", i++); // possibly make this more friendly
           }
         }
       }

--- a/ServerTransport/Server.cs
+++ b/ServerTransport/Server.cs
@@ -40,6 +40,8 @@ namespace Speckle.Core.Transports
 
     public Action<string, int> OnProgressAction { get; set; }
 
+    public Action<string, int> OnErrorAction { get; set; }
+
     public Account Account { get; set; }
 
     public ServerTransport(Account account, string streamId, int timeoutSeconds = 60)

--- a/ServerTransport/Server.cs
+++ b/ServerTransport/Server.cs
@@ -332,7 +332,8 @@ namespace Speckle.Core.Transports
               if (partial.__closure != null)
                 onTotalChildrenCountKnown?.Invoke(partial.__closure.Count);
             }
-            OnProgressAction?.Invoke($"GET Remote ({Client.BaseAddress})", i++); // possibly make this more friendly
+            OnProgressAction?.Invoke(TransportName, 1); // possibly make this more friendly
+            i++;
           }
         }
       }

--- a/ServerTransport/Server.cs
+++ b/ServerTransport/Server.cs
@@ -109,6 +109,7 @@ namespace Speckle.Core.Transports
       if (CancellationToken.IsCancellationRequested)
       {
         Queue = new ConcurrentQueue<(string, string, int)>();
+        IS_WRITING = false;
         return;
       }
 
@@ -128,6 +129,7 @@ namespace Speckle.Core.Transports
       if (CancellationToken.IsCancellationRequested)
       {
         Queue = new ConcurrentQueue<(string, string, int)>();
+        IS_WRITING = false;
         return;
       }
 
@@ -153,6 +155,7 @@ namespace Speckle.Core.Transports
         if (CancellationToken.IsCancellationRequested)
         {
           Queue = new ConcurrentQueue<(string, string, int)>();
+          IS_WRITING = false;
           return;
         }
 
@@ -187,6 +190,7 @@ namespace Speckle.Core.Transports
       if (CancellationToken.IsCancellationRequested)
       {
         Queue = new ConcurrentQueue<(string, string, int)>();
+        IS_WRITING = false;
         return;
       }
 
@@ -220,6 +224,7 @@ namespace Speckle.Core.Transports
       if (CancellationToken.IsCancellationRequested)
       {
         Queue = new ConcurrentQueue<(string, string, int)>();
+        IS_WRITING = false;
         return;
       }
 
@@ -237,6 +242,7 @@ namespace Speckle.Core.Transports
       if (CancellationToken.IsCancellationRequested)
       {
         Queue = new ConcurrentQueue<(string, string, int)>();
+        IS_WRITING = false;
         return;
       }
 

--- a/Tests/Kits.cs
+++ b/Tests/Kits.cs
@@ -22,6 +22,7 @@ namespace Tests
     [Ignore("Not going to work unless you have a kit installed.")]
     public void LoadConverter()
     {
+      return;
       var kits = KitManager.Kits;
       var cp = kits;
       var objsk = kits.ElementAt(2);

--- a/Tests/Kits.cs
+++ b/Tests/Kits.cs
@@ -18,19 +18,5 @@ namespace Tests
       Assert.Greater(types.Count(), 0);
     }
 
-    [Test]
-    [Ignore("Not going to work unless you have a kit installed.")]
-    public void LoadConverter()
-    {
-      return;
-      var kits = KitManager.Kits;
-      var cp = kits;
-      var objsk = kits.ElementAt(2);
-
-      var conv = objsk.Converters;
-      var cpc = conv;
-    }
-
-
   }
 }

--- a/Tests/SendReceiveLocal.cs
+++ b/Tests/SendReceiveLocal.cs
@@ -194,29 +194,29 @@ namespace Tests
       Assert.GreaterOrEqual(progress.Keys.Count, 1);
     }
 
-    [Test]
-    public async Task DiskTransportTest()
-    {
-      var myObject = new Base();
-      myObject["@items"] = new List<Base>();
-      myObject["test"] = "random";
+    //[Test]
+    //public async Task DiskTransportTest()
+    //{
+    //  var myObject = new Base();
+    //  myObject["@items"] = new List<Base>();
+    //  myObject["test"] = "random";
 
-      var rand = new Random();
+    //  var rand = new Random();
 
-      for (int i = 0; i < 100; i++)
-      {
-        ((List<Base>)myObject["@items"]).Add(new Point(i, i, i) { applicationId = i + "-___/---" });
-      }
+    //  for (int i = 0; i < 100; i++)
+    //  {
+    //    ((List<Base>)myObject["@items"]).Add(new Point(i, i, i) { applicationId = i + "-___/---" });
+    //  }
 
-      var dt = new DiskTransport.DiskTransport();
-      var id = await Operations.Send(myObject, new List<ITransport>() { dt }, false);
+    //  var dt = new DiskTransport.DiskTransport();
+    //  var id = await Operations.Send(myObject, new List<ITransport>() { dt }, false);
 
-      Assert.IsNotNull(id);
+    //  Assert.IsNotNull(id);
 
-      var rebase = await Operations.Receive(id, dt);
+    //  var rebase = await Operations.Receive(id, dt);
 
-      Assert.AreEqual(rebase.GetId(true), id);
-    }
+    //  Assert.AreEqual(rebase.GetId(true), id);
+    //}
 
   }
 }

--- a/Tests/SendReceiveLocal.cs
+++ b/Tests/SendReceiveLocal.cs
@@ -194,30 +194,29 @@ namespace Tests
       Assert.GreaterOrEqual(progress.Keys.Count, 1);
     }
 
-    [Test]
-    public async Task DiskTransportTest()
-    {
-      var myObject = new Base();
-      myObject["@items"] = new List<Base>();
-      myObject["test"] = "random";
+    //[Test]
+    //public async Task DiskTransportTest()
+    //{
+    //  var myObject = new Base();
+    //  myObject["@items"] = new List<Base>();
+    //  myObject["test"] = "random";
 
-      var rand = new Random();
+    //  var rand = new Random();
 
-      for (int i = 0; i < 100; i++)
-      {
-        ((List<Base>)myObject["@items"]).Add(new Point(i, i, i) { applicationId = i + "-___/---" });
-      }
+    //  for (int i = 0; i < 100; i++)
+    //  {
+    //    ((List<Base>)myObject["@items"]).Add(new Point(i, i, i) { applicationId = i + "-___/---" });
+    //  }
 
-      var dt = new DiskTransport.DiskTransport(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "SpeckleTests", "Objects"));
-      var id = await Operations.Send(myObject, new List<ITransport>() { dt }, false);
+    //  var dt = new DiskTransport.DiskTransport(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SpeckleTests", "Objects"));
+    //  var id = await Operations.Send(myObject, new List<ITransport>() { dt }, false);
 
-      Assert.IsNotNull(id);
+    //  Assert.IsNotNull(id);
 
-      var rebase = await Operations.Receive(id, dt);
+    //  var rebase = await Operations.Receive(id, dt);
 
-      Assert.AreEqual(rebase.GetId(true), id);
-    }
-
+    //  Assert.AreEqual(rebase.GetId(true), id);
+    //}
 
   }
 }

--- a/Tests/SendReceiveLocal.cs
+++ b/Tests/SendReceiveLocal.cs
@@ -194,29 +194,29 @@ namespace Tests
       Assert.GreaterOrEqual(progress.Keys.Count, 1);
     }
 
-    //[Test]
-    //public async Task DiskTransportTest()
-    //{
-    //  var myObject = new Base();
-    //  myObject["@items"] = new List<Base>();
-    //  myObject["test"] = "random";
+    [Test]
+    public async Task DiskTransportTest()
+    {
+      var myObject = new Base();
+      myObject["@items"] = new List<Base>();
+      myObject["test"] = "random";
 
-    //  var rand = new Random();
+      var rand = new Random();
 
-    //  for (int i = 0; i < 100; i++)
-    //  {
-    //    ((List<Base>)myObject["@items"]).Add(new Point(i, i, i) { applicationId = i + "-___/---" });
-    //  }
+      for (int i = 0; i < 100; i++)
+      {
+        ((List<Base>)myObject["@items"]).Add(new Point(i, i, i) { applicationId = i + "-___/---" });
+      }
 
-    //  var dt = new DiskTransport.DiskTransport(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SpeckleTests", "Objects"));
-    //  var id = await Operations.Send(myObject, new List<ITransport>() { dt }, false);
+      var dt = new DiskTransport.DiskTransport(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SpeckleTests", "Objects"));
+      var id = await Operations.Send(myObject, new List<ITransport>() { dt }, false);
 
-    //  Assert.IsNotNull(id);
+      Assert.IsNotNull(id);
 
-    //  var rebase = await Operations.Receive(id, dt);
+      var rebase = await Operations.Receive(id, dt);
 
-    //  Assert.AreEqual(rebase.GetId(true), id);
-    //}
+      Assert.AreEqual(rebase.GetId(true), id);
+    }
 
   }
 }

--- a/Tests/SendReceiveLocal.cs
+++ b/Tests/SendReceiveLocal.cs
@@ -179,7 +179,7 @@ namespace Tests
       });
 
       Assert.NotNull(progress);
-      Assert.Contains("Serialization", progress.Keys.ToArray());
+      Assert.GreaterOrEqual(progress.Keys.Count, 1);
     }
 
     [Test(Description = "Should show progress!"), Order(5)]
@@ -191,7 +191,7 @@ namespace Tests
         progress = dict;
       });
       Assert.NotNull(progress);
-      Assert.Contains("Deserialization", progress.Keys.ToArray());
+      Assert.GreaterOrEqual(progress.Keys.Count, 1);
     }
 
     [Test]

--- a/Tests/SendReceiveLocal.cs
+++ b/Tests/SendReceiveLocal.cs
@@ -208,7 +208,7 @@ namespace Tests
         ((List<Base>)myObject["@items"]).Add(new Point(i, i, i) { applicationId = i + "-___/---" });
       }
 
-      var dt = new DiskTransport.DiskTransport(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SpeckleTests", "Objects"));
+      var dt = new DiskTransport.DiskTransport();
       var id = await Operations.Send(myObject, new List<ITransport>() { dt }, false);
 
       Assert.IsNotNull(id);

--- a/Tests/TestsUnit.csproj
+++ b/Tests/TestsUnit.csproj
@@ -1,17 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
     <ProjectReference Include="..\DiskTransport\DiskTransport.csproj" />


### PR DESCRIPTION
Changes in a nutshell: 
- transports can be cancelled (re #35)
- send can be cancelled (re #35)
- transports can bubble up errors (closes #4)
- gql api calls can be cancelled

- [x] receive should be cancellable (untested, needs connector work)
- [x] serialize should be cancellable (untested, needs connector work)
- [x] deserialize should be cancellable (untested, needs connector work)
- adds StreamWrapper class for ease of use of (stream, account) structs in dynamo/gh 

