### PR TITLE
Server Transport Improvements

### DIFF
--- a/Transports/ServerTransport/Server.cs
+++ b/Transports/ServerTransport/Server.cs
@@ -33,9 +33,9 @@ namespace Speckle.Core.Transports
 
     private bool IS_WRITING = false;
 
-    private int MAX_BUFFER_SIZE = 250_000;
+    private int MAX_BUFFER_SIZE = 500_000;
 
-    private int MAX_MULTIPART_COUNT = 4;
+    private int MAX_MULTIPART_COUNT = 10;
 
     public int SavedObjectCount { get; private set; } = 0;
 
@@ -147,11 +147,12 @@ namespace Speckle.Core.Transports
       };
 
       var multipart = new MultipartFormDataContent("--obj--");
-      var contents = new List<string>();
 
       ValueTuple<string, string, int> result;
       SavedObjectCount = 0;
-      while (contents.Count < MAX_MULTIPART_COUNT && Queue.Count != 0)
+      var addedMpCount = 0;
+
+      while (addedMpCount < MAX_MULTIPART_COUNT && Queue.Count != 0)
       {
         if (CancellationToken.IsCancellationRequested)
         {
@@ -183,6 +184,7 @@ namespace Speckle.Core.Transports
         }
         _ct += "]";
         multipart.Add(new StringContent(_ct, Encoding.UTF8), $"batch-{i}", $"batch-{i}");
+        addedMpCount++;
         SavedObjectCount += i;
       }
 


### PR DESCRIPTION
One major hotfix in queue processing and handling 😬
Improvements: 
- can gzip payloads (upload size reduced 3x to 10x)
- flag for compression, in case some might want to set it to false (ie, local network scenarios where latency is a secondary concern)

Includes other tweaks and balancing acts in the server transport: 
- MAX_BUFFER_SIZE: set 100k to avoid over-pressuring mem/cpu on server
- MAX_MULITPART_COUNT: set to 500
- PollInterval increased to 100ms to ensure higher chunks being sent

Measurements (benchmarks):
 
A) heterogenous payload (approx 10k objs for "slider @ 5000"):
```
57s - slider @ 5000; MBF = 2mb, MPC = 10
85s - slider @ 5000, MBF = 1mb, MPC = 3
56s - slider @ 5000, MBF = 1mb, MPC = 20
48s - slider @ 5000, MBF = 1mb, MPC = 50
50s - slider @ 5000, MBF = 2mb, MPC = 100
48s - slider @ 5000, MBF = 1mb, MPC = 100
44s - slider @ 5000, MBF = 500k, MPC = 200
43s - slider @ 5000, MBF = 500k, MPC = 500
36s - slider @ 5000, MBF = 250k, MPC = 500
34s - slider @ 5000, MBF = 100k, MPC = 500
32s - slider @ 5000, MBF = 100k, MPC = 500 (rerun)
33s - slider @ 5000, MBF = 100k, MPC = 500 (rerun)
36s - slider @ 5000, MBF = 50k, MPC = 500
36s - slider @ 5000, MBF = 50k, MPC = 500 (rerun)
33s - slider @ 5000, MBF = 100k, MPC = 250
33s - slider @ 5000, MBF = 100k, MPC = 1000
```

B) homogenous payload (approx 10k objs for "slider @ 5000"):
```
36s - slider @ 5000, MBF = 100k, MPC = 500
37s - slider @ 5000, MBF = 100k, MPC = 500
10s  - slider @ 1000, MBF = 100k, MPC = 500
9.8s  - slider @ 1000, MBF = 100k, MPC = 500
```

C) simultaneous uploads (this was mostly testing my internet connection upload speed):
```
46s - slider @ 5000, MBF = 100k, MPC = 500; 2 simultaneous uploads
63s - slider @ 5000, MBF = 100k, MPC = 500; 3 simultaneous uploads
57s - slider @ 5001, MBF = 100k, MPC = 500; 3 simultaneous uploads
56s - slider @ 5001, MBF = 100k, MPC = 500; 3 simultaneous uploads
123s - slider @ 5001, MBF = 100k, MPC = 500; 6 simultaneous uploads
33s - slider @ 1000, MBF = 100k, MPC = 500; 8 simultaneous uploads
35s - slider @ 1000, MBF = 100k, MPC = 500; 8 simultaneous uploads (rerun)
154s - slider @ 5000, MBF = 100k, MPC = 500; 8 simultaneous uploads
149s - slider @ 5000, MBF = 100k, MPC = 500; 8 simultaneous uploads (rerun)
```

D) incomplete compression on/off benchmarks:
```
34s - slider @ 5000 compression on
121s - slider @ 5000 compression off
123s - slider @ 5000 compression off (rerun)
34s - slider @ 5000 compression on (rerun)
```
