### PR TITLE
fix(copy): fixes the shallow copy func to not change type

### DIFF
--- a/Core/Models/Base.cs
+++ b/Core/Models/Base.cs
@@ -136,11 +136,23 @@ namespace Speckle.Core.Models
     /// <returns>A shallow copy of the original object.</returns>
     public Base ShallowCopy()
     {
-      var @base = new Base {id = id, applicationId = applicationId};
+      var myDuplicate = (Base) Activator.CreateInstance(GetType());
+      myDuplicate.id = id;
+      myDuplicate.applicationId = applicationId;
 
-      GetDynamicMembers().ToList().ForEach(prop => @base[prop] = this[prop]);
+      foreach(var prop in GetDynamicMemberNames())
+      {
+        try
+        {
+          myDuplicate[prop] = this[prop];
+        }
+        catch
+        {
+          // avoids unsettable props
+        }
+      }
 
-      return @base;
+      return myDuplicate;
     }
     
     /// <summary>


### PR DESCRIPTION
now it can shallow copy any base-derived types

fix #61